### PR TITLE
Android Day 4: Finish home screen & navbar

### DIFF
--- a/EZRecipes/app/build.gradle
+++ b/EZRecipes/app/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation "androidx.compose.material:material:$compose_ui_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_ui_version"
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'androidx.navigation:navigation-compose:2.5.3'
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/MockRecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/MockRecipeService.kt
@@ -15,7 +15,7 @@ object MockRecipeService: RecipeService {
     private const val recipeErrorString = "{\"error\":\"You are not authorized. Please read https://spoonacular.com/food-api/docs#Authentication\"}"
     val recipeError: RecipeError = Gson().fromJson(recipeErrorString, RecipeError::class.java)
 
-    var isSuccess = false // controls whether the mock API calls succeed or fail
+    var isSuccess = true // controls whether the mock API calls succeed or fail
 
     override suspend fun getRandomRecipe(): Response<Recipe> {
         return if (isSuccess) {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/MockRecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/MockRecipeService.kt
@@ -1,7 +1,9 @@
 package com.abhiek.ezrecipes.data
 
 import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.models.RecipeError
 import com.google.gson.Gson
+import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 
 // Send hardcoded recipe responses for tests
@@ -10,11 +12,24 @@ object MockRecipeService: RecipeService {
     private const val recipeString = "{\"id\":635562,\"name\":\"Blueberry-Pineapple Salad\",\"url\":\"https://spoonacular.com/blueberry-pineapple-salad-635562\",\"image\":\"https://spoonacular.com/recipeImages/635562-312x231.jpg\",\"credit\":\"Foodista.com – The Cooking Encyclopedia Everyone Can Edit\",\"sourceUrl\":\"http://www.foodista.com/recipe/R84BP3YJ/blueberry-pineapple-salad\",\"healthScore\":1,\"time\":45,\"servings\":10,\"summary\":\"Blueberry-Pineapple Salad might be just the side dish you are searching for. For <b>93 cents per serving</b>, this recipe <b>covers 4%</b> of your daily requirements of vitamins and minerals. One serving contains <b>297 calories</b>, <b>2g of protein</b>, and <b>13g of fat</b>. If you have cream, sugar, milk, and a few other ingredients on hand, you can make it. 1 person has made this recipe and would make it again. It is a good option if you're following a <b>gluten free</b> diet. From preparation to the plate, this recipe takes approximately <b>45 minutes</b>. All things considered, we decided this recipe <b>deserves a spoonacular score of 19%</b>. This score is not so amazing. Try <a href=\\\"https://spoonacular.com/recipes/kale-blueberry-pineapple-salad-672624\\\">Kale Blueberry Pineapple Salad</a>, <a href=\\\"https://spoonacular.com/recipes/blueberry-cantaloupe-and-pineapple-salad-thesaladbar-496507\\\">Blueberry, Cantaloupe and Pineapple Salad #TheSaladBar</a>, and <a href=\\\"https://spoonacular.com/recipes/chicken-strawberry-blueberry-pineapple-salad-with-poppy-seed-dressing-603148\\\">Chicken Strawberry Blueberry Pineapple Salad With Poppy Seed Dressing</a> for similar recipes.\",\"nutrients\":[{\"name\":\"Calories\",\"amount\":299.3,\"unit\":\"kcal\"},{\"name\":\"Fat\",\"amount\":12.58,\"unit\":\"g\"},{\"name\":\"Saturated Fat\",\"amount\":6.93,\"unit\":\"g\"},{\"name\":\"Carbohydrates\",\"amount\":47.28,\"unit\":\"g\"},{\"name\":\"Fiber\",\"amount\":1.76,\"unit\":\"g\"},{\"name\":\"Sugar\",\"amount\":43.99,\"unit\":\"g\"},{\"name\":\"Protein\",\"amount\":2.58,\"unit\":\"g\"},{\"name\":\"Cholesterol\",\"amount\":36.54,\"unit\":\"mg\"},{\"name\":\"Sodium\",\"amount\":80.29,\"unit\":\"mg\"}],\"ingredients\":[{\"id\":9050,\"name\":\"blueberries\",\"amount\":1.5,\"unit\":\"ounces\"},{\"id\":9354,\"name\":\"canned pineapple\",\"amount\":0.1,\"unit\":\"can\"},{\"id\":10419172,\"name\":\"cherry gelatin\",\"amount\":0.1,\"unit\":\"large\"},{\"id\":1017,\"name\":\"cream cheese\",\"amount\":0.8,\"unit\":\"ounces\"},{\"id\":1077,\"name\":\"milk\",\"amount\":0.1,\"unit\":\"teaspoon\"},{\"id\":1056,\"name\":\"sour cream\",\"amount\":0.1,\"unit\":\"cup\"},{\"id\":19335,\"name\":\"sugar\",\"amount\":0.15,\"unit\":\"cups\"}],\"instructions\":[{\"name\":\"\",\"steps\":[{\"number\":1,\"step\":\"Drain liquid from fruit and add water or fruit juice to make 3 cups. Make gelatin with the 3 cups heated liquid. Chill. When it starts to set, add fruit.\",\"ingredients\":[{\"id\":1029016,\"name\":\"fruit juice\",\"image\":\"apple-juice.jpg\"},{\"id\":19177,\"name\":\"gelatin\",\"image\":\"gelatin-powder.jpg\"},{\"id\":9431,\"name\":\"fruit\",\"image\":\"mixed-fresh-fruit.jpg\"},{\"id\":14412,\"name\":\"water\",\"image\":\"water.png\"}],\"equipment\":[]},{\"number\":2,\"step\":\"Mix ingredients for topping and spread on set salad.\",\"ingredients\":[{\"id\":0,\"name\":\"spread\",\"image\":\"\"}],\"equipment\":[]},{\"number\":3,\"step\":\"Serves 8-10\",\"ingredients\":[],\"equipment\":[]}]}]}"
     val recipe: Recipe = Gson().fromJson(recipeString, Recipe::class.java)
 
+    private const val recipeErrorString = "{\"error\":\"You are not authorized. Please read https://spoonacular.com/food-api/docs#Authentication\"}"
+    val recipeError: RecipeError = Gson().fromJson(recipeErrorString, RecipeError::class.java)
+
+    var isSuccess = false // controls whether the mock API calls succeed or fail
+
     override suspend fun getRandomRecipe(): Response<Recipe> {
-        return Response.success(recipe)
+        return if (isSuccess) {
+            Response.success(recipe)
+        } else {
+            Response.error(401, recipeErrorString.toResponseBody())
+        }
     }
 
     override suspend fun getRecipeById(id: Int): Response<Recipe> {
-        return Response.success(recipe)
+        return if (isSuccess) {
+            Response.success(recipe)
+        } else {
+            Response.error(401, recipeErrorString.toResponseBody())
+        }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/RecipeRepository.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/RecipeRepository.kt
@@ -1,44 +1,70 @@
 package com.abhiek.ezrecipes.data
 
 import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.models.RecipeError
+import com.abhiek.ezrecipes.utils.Constants
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import retrofit2.Response
 
 // Connects the ViewModel to the DataSource
 // Using dependency injection for happy little tests
 class RecipeRepository(private val recipeService: RecipeService) {
-    suspend fun getRandomRecipe(): Result<Recipe> {
+    suspend fun getRandomRecipe(): RecipeResult {
         val response: Response<Recipe>
 
         try {
             response = recipeService.getRandomRecipe()
         } catch (error: Exception) {
             // Catch ConnectExceptions, UnknownHostExceptions, etc.
-            return Result.failure(error)
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            return RecipeResult.Error(recipeError)
         }
 
         // isSuccessful means a 2xx response code
         return if (response.isSuccessful && response.body() != null) {
-            Result.success(response.body()!!)
+            RecipeResult.Success(response.body()!!)
         } else {
-            Result.failure(Exception(response.errorBody()?.string()))
+            val errorString = response.errorBody()?.string()
+
+            val recipeError = try {
+                // Try to parse the response as a RecipeError
+                Gson().fromJson(errorString, RecipeError::class.java)
+            } catch (error: JsonSyntaxException) {
+                // Otherwise, set the error property as the raw error string
+                RecipeError(errorString ?: Constants.UNKNOWN_ERROR)
+            }
+
+            return RecipeResult.Error(recipeError)
         }
     }
 
-    suspend fun getRecipeById(id: Int): Result<Recipe> {
+    suspend fun getRecipeById(id: Int): RecipeResult {
         val response: Response<Recipe>
 
         try {
             response = recipeService.getRecipeById(id)
         } catch (error: Exception) {
             // Catch ConnectExceptions, UnknownHostExceptions, etc.
-            return Result.failure(error)
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            return RecipeResult.Error(recipeError)
         }
 
         // isSuccessful means a 2xx response code
         return if (response.isSuccessful && response.body() != null) {
-            Result.success(response.body()!!)
+            RecipeResult.Success(response.body()!!)
         } else {
-            Result.failure(Exception(response.errorBody()?.string()))
+            val errorString = response.errorBody()?.string()
+
+            val recipeError = try {
+                // Try to parse the response as a RecipeError
+                Gson().fromJson(errorString, RecipeError::class.java)
+            } catch (error: JsonSyntaxException) {
+                // Otherwise, set the error property as the raw error string
+                RecipeError(errorString ?: Constants.UNKNOWN_ERROR)
+            }
+
+            return RecipeResult.Error(recipeError)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/RecipeResult.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/RecipeResult.kt
@@ -1,0 +1,10 @@
+package com.abhiek.ezrecipes.data
+
+import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.models.RecipeError
+
+// Custom Result class to hold Recipe objects on success and RecipeError objects on error
+sealed class RecipeResult {
+    data class Success(val recipe: Recipe): RecipeResult()
+    data class Error(val recipeError: RecipeError): RecipeResult()
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
@@ -3,13 +3,7 @@ package com.abhiek.ezrecipes.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import com.abhiek.ezrecipes.R
-import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,28 +11,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            EZRecipesTheme {
-                Scaffold (
-                    topBar = {
-                        TopAppBar(
-                            title = {
-                                Text(text = stringResource(R.string.app_name))
-                            },
-                            backgroundColor = MaterialTheme.colors.primary
-                        )
-                    },
-                    // Content padding parameter is required: https://stackoverflow.com/a/72085218
-                    content = { padding ->
-                        // A surface container using the 'background' color from the theme
-                        Surface(
-                            modifier = Modifier.padding(padding),
-                            color = MaterialTheme.colors.background
-                        ) {
-                            NavigationGraph()
-                        }
-                    }
-                )
-            }
+            MainLayout()
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
@@ -18,7 +18,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun MainLayout(initialDrawerState: DrawerValue = DrawerValue.Open) {
+fun MainLayout(initialDrawerState: DrawerValue = DrawerValue.Closed) {
     // Remember functions can only be called in a composable, not an activity
     val scope = rememberCoroutineScope()
     val scaffoldState = rememberScaffoldState(rememberDrawerState(initialDrawerState))

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
@@ -1,0 +1,66 @@
+package com.abhiek.ezrecipes.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.navigation.compose.rememberNavController
+import com.abhiek.ezrecipes.ui.navbar.NavigationDrawer
+import com.abhiek.ezrecipes.ui.navbar.NavigationGraph
+import com.abhiek.ezrecipes.ui.navbar.TopBar
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+
+@Composable
+fun MainLayout(initialDrawerState: DrawerValue = DrawerValue.Open) {
+    // Remember functions can only be called in a composable, not an activity
+    val scope = rememberCoroutineScope()
+    val scaffoldState = rememberScaffoldState(rememberDrawerState(initialDrawerState))
+    // The navigation controller shouldn't be recreated in other composables
+    val navController = rememberNavController()
+
+    // Great resource for setting up the navigation drawer: https://stackoverflow.com/a/73295465
+    EZRecipesTheme {
+        Scaffold (
+            scaffoldState = scaffoldState,
+            topBar = { TopBar(scope, scaffoldState) },
+            drawerContent = {
+                NavigationDrawer(scope, scaffoldState, navController)
+            },
+            // Content padding parameter is required: https://stackoverflow.com/a/72085218
+            content = { padding ->
+                // A surface container using the 'background' color from the theme
+                Surface(
+                    modifier = Modifier.padding(padding),
+                    color = MaterialTheme.colors.background
+                ) {
+                    NavigationGraph(navController)
+                }
+            }
+        )
+    }
+}
+
+private class MainLayoutPreviewParameterProvider: PreviewParameterProvider<DrawerValue> {
+    // Show a preview of the drawer when opened and closed
+    override val values = sequenceOf(DrawerValue.Open, DrawerValue.Closed)
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun MainLayoutPreview(
+    @PreviewParameter(MainLayoutPreviewParameterProvider::class) drawerState: DrawerValue
+) {
+    EZRecipesTheme {
+        MainLayout(drawerState)
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -20,9 +20,8 @@ class MainViewModel(
         private set
     var recipeError by mutableStateOf<RecipeError?>(null)
         private set
+
     var isLoading by mutableStateOf(false)
-        private set
-    // Let the view change this property
     var isRecipeLoaded by mutableStateOf(false)
     var showRecipeAlert by mutableStateOf(false)
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.abhiek.ezrecipes.data.RecipeRepository
+import com.abhiek.ezrecipes.data.RecipeResult
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.models.RecipeError
 import kotlinx.coroutines.launch
@@ -23,6 +24,7 @@ class MainViewModel(
         private set
     // Let the view change this property
     var isRecipeLoaded by mutableStateOf(false)
+    var showRecipeAlert by mutableStateOf(false)
 
     fun getRandomRecipe() {
         viewModelScope.launch {
@@ -30,20 +32,20 @@ class MainViewModel(
             val response = recipeRepository.getRandomRecipe()
             isLoading = false
 
-            response.fold(
-                onSuccess = { recipe ->
-                    this@MainViewModel.recipe = recipe
+            when (response) {
+                is RecipeResult.Success -> {
+                    recipe = response.recipe
                     recipeError = null
                     isRecipeLoaded = true
-                },
-                onFailure = { error ->
-                    recipe = null
-                    recipeError = RecipeError(
-                        error.localizedMessage ?:
-                        "Something went terribly wrong. Please submit a bug report to https://github.com/Abhiek187/ez-recipes-android/issues"
-                    )
+                    showRecipeAlert = false
                 }
-            )
+                is RecipeResult.Error -> {
+                    recipe = null
+                    recipeError = response.recipeError
+                    isRecipeLoaded = false
+                    showRecipeAlert = true
+                }
+            }
         }
     }
 
@@ -53,19 +55,20 @@ class MainViewModel(
             val response = recipeRepository.getRecipeById(id)
             isLoading = false
 
-            response.fold(
-                onSuccess = { recipe ->
-                    this@MainViewModel.recipe = recipe
+            when (response) {
+                is RecipeResult.Success -> {
+                    recipe = response.recipe
                     recipeError = null
-                },
-                onFailure = { error ->
-                    recipe = null
-                    recipeError = RecipeError(
-                        error.localizedMessage ?:
-                        "Something went terribly wrong. Please submit a bug report to https://github.com/Abhiek187/ez-recipes-android/issues"
-                    )
+                    isRecipeLoaded = true
+                    showRecipeAlert = false
                 }
-            )
+                is RecipeResult.Error -> {
+                    recipe = null
+                    recipeError = response.recipeError
+                    isRecipeLoaded = false
+                    showRecipeAlert = true
+                }
+            }
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -122,10 +122,15 @@ private class HomePreviewParameterProvider: PreviewParameterProvider<HomeState> 
 private fun HomePreview(
     @PreviewParameter(HomePreviewParameterProvider::class) state: HomeState
 ) {
-    val viewModel = MainViewModel(RecipeRepository(MockRecipeService))
+    val recipeService = MockRecipeService
+    val viewModel = MainViewModel(RecipeRepository(recipeService))
     val (isLoading, showAlert) = state
     viewModel.isLoading = isLoading
-    viewModel.showRecipeAlert = showAlert
+    //viewModel.showRecipeAlert = showAlert
+
+    if (showAlert) {
+        recipeService.isSuccess = false
+    }
 
     EZRecipesTheme {
         Surface {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -1,8 +1,6 @@
 package com.abhiek.ezrecipes.ui.home
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -87,14 +85,22 @@ fun Home(
                        )
                 },
                 buttons = {
-                    Button(
-                        onClick = {
-                            mainViewModel.showRecipeAlert = false
-                        }
+                    // Position the button at the bottom right of the alert
+                    Row(
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
                     ) {
-                        Text(
-                            text = stringResource(R.string.ok_button)
-                        )
+                        Button(
+                            onClick = {
+                                mainViewModel.showRecipeAlert = false
+                            }
+                        ) {
+                            Text(
+                                text = stringResource(R.string.ok_button)
+                            )
+                        }
                     }
                 }
             )
@@ -129,11 +135,8 @@ private fun HomePreview(
     val viewModel = MainViewModel(RecipeRepository(recipeService))
     val (isLoading, showAlert) = state
     viewModel.isLoading = isLoading
-    //viewModel.showRecipeAlert = showAlert
-
-    if (showAlert) {
-        recipeService.isSuccess = false
-    }
+    viewModel.showRecipeAlert = showAlert // show the fallback alert in the preview
+    recipeService.isSuccess = !showAlert // show the alert after clicking the find recipe button
 
     EZRecipesTheme {
         Surface {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.abhiek.ezrecipes.R
@@ -63,7 +65,53 @@ fun Home(
         if (mainViewModel.isLoading) {
             CircularProgressIndicator()
         }
+        
+        // Show an alert if the recipe failed to load
+        if (mainViewModel.showRecipeAlert) {
+            AlertDialog(
+                onDismissRequest = {
+                    mainViewModel.showRecipeAlert = false
+                },
+                title = {
+                    Text(
+                        text = stringResource(R.string.error_title)
+                    )
+                },
+                text = {
+                       Text(
+                           text = mainViewModel.recipeError?.error ?:
+                           stringResource(R.string.unknown_error)
+                       )
+                },
+                buttons = {
+                    Button(
+                        onClick = {
+                            mainViewModel.showRecipeAlert = false
+                        }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.ok_button)
+                        )
+                    }
+                }
+            )
+        }
     }
+}
+
+// Show different previews for each possible state of the home screen
+private data class HomeState(
+    val isLoading: Boolean,
+    val showAlert: Boolean
+)
+
+private class HomePreviewParameterProvider: PreviewParameterProvider<HomeState> {
+    // Show previews of the default home screen, with the progress bar, and with an alert
+    override val values = sequenceOf(
+        HomeState(isLoading = false, showAlert = false),
+        HomeState(isLoading = true, showAlert = false),
+        HomeState(isLoading = false, showAlert = true)
+    )
 }
 
 @DevicePreviews
@@ -71,8 +119,13 @@ fun Home(
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun HomePreview() {
+private fun HomePreview(
+    @PreviewParameter(HomePreviewParameterProvider::class) state: HomeState
+) {
     val viewModel = MainViewModel(RecipeRepository(MockRecipeService))
+    val (isLoading, showAlert) = state
+    viewModel.isLoading = isLoading
+    viewModel.showRecipeAlert = showAlert
 
     EZRecipesTheme {
         Surface {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -62,9 +63,11 @@ fun Home(
         }
 
         // Show a progress bar while the recipe is loading
-        if (mainViewModel.isLoading) {
-            CircularProgressIndicator()
-        }
+        // Make it hidden so the button stays in place
+        CircularProgressIndicator(
+            modifier = Modifier
+                .alpha(if (mainViewModel.isLoading) 1f else 0f)
+        )
         
         // Show an alert if the recipe failed to load
         if (mainViewModel.showRecipeAlert) {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerItem.kt
@@ -1,0 +1,7 @@
+package com.abhiek.ezrecipes.ui.navbar
+
+// Routes and their associated titles in the navigation graph
+sealed class DrawerItem(val route: String, val title: String) {
+    object Home: DrawerItem("home", "Home")
+    object Recipe: DrawerItem("recipe/{recipe}", "")
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerItem.kt
@@ -1,7 +1,13 @@
 package com.abhiek.ezrecipes.ui.navbar
 
-// Routes and their associated titles in the navigation graph
-sealed class DrawerItem(val route: String, val title: String) {
-    object Home: DrawerItem("home", "Home")
-    object Recipe: DrawerItem("recipe/{recipe}", "")
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.ui.graphics.vector.ImageVector
+
+// Routes and their associated titles and icons in the navigation graph
+sealed class DrawerItem(val route: String, val title: String, val icon: ImageVector) {
+    // Icons: https://fonts.google.com/icons (some require material-icons-extended)
+    object Home: DrawerItem("home", "Home", Icons.Filled.Home)
+    object Recipe: DrawerItem("recipe/{recipe}", "Recipe", Icons.Filled.MenuBook)
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
@@ -1,0 +1,67 @@
+package com.abhiek.ezrecipes.ui.navbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+
+@Composable
+fun DrawerListItem(item: DrawerItem, selected: Boolean, onItemClick: () -> Unit) {
+    // Highlight the selected drawer item
+    val backgroundColor = if (selected) MaterialTheme.colors.secondary else Color.Transparent
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onItemClick)
+            .height(50.dp)
+            .background(backgroundColor)
+            .padding(start = 16.dp)
+    ) {
+        Icon(
+            imageVector = item.icon,
+            contentDescription = item.title,
+            modifier = Modifier
+                .height(32.dp)
+                .width(32.dp),
+            // In dark mode, black contrasts with yellow better than white
+            tint = if (selected) Color.Black else MaterialTheme.colors.onBackground
+        )
+        Spacer(
+            modifier = Modifier.width(16.dp)
+        )
+        Text(
+            text = item.title,
+            fontSize = 18.sp,
+            color = if (selected) Color.Black else MaterialTheme.colors.onBackground
+        )
+    }
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+fun DrawerListItemPreview() {
+    EZRecipesTheme {
+        Column {
+            DrawerListItem(item = DrawerItem.Home, selected = true) {}
+            DrawerListItem(item = DrawerItem.Recipe, selected = false) {}
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -2,19 +2,19 @@ package com.abhiek.ezrecipes.ui.navbar
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.DrawerValue
 import androidx.compose.material.ScaffoldState
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
@@ -38,27 +38,31 @@ fun NavigationDrawer(
         DrawerItem.Home
     )
 
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+
     Column {
         // Show the app logo at the top
-//        Image(
-//            painter = painterResource(R.mipmap.ic_launcher_foreground),
-//            contentDescription = stringResource(R.string.app_logo_alt),
-//            modifier = Modifier
-//                .height(100.dp)
-//                .fillMaxWidth()
-//                .padding(8.dp)
-//        )
-//        Spacer(
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .height(8.dp)
-//        )
+        Image(
+            painter = painterResource(R.mipmap.ic_launcher_foreground),
+            contentDescription = stringResource(R.string.app_logo_alt),
+            modifier = Modifier
+                .height(100.dp)
+                .fillMaxWidth()
+                .padding(8.dp)
+        )
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+        )
         // Loop through all the subclasses of the sealed DrawerItem class
         drawerItems.forEach { item ->
-            // Show text that can be clicked on to navigate to the appropriate screen
-            ClickableText(
-                text = AnnotatedString(item.title),
-                onClick = {
+            DrawerListItem(
+                item = item,
+                // Highlight the drawer item corresponding to the current route on screen
+                selected = currentRoute == item.route,
+                onItemClick = {
                     navController.navigate(item.route) {
                         navController.graph.startDestinationRoute?.let { route ->
                             popUpTo(route) {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -1,0 +1,93 @@
+package com.abhiek.ezrecipes.ui.navbar
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.DrawerValue
+import androidx.compose.material.ScaffoldState
+import androidx.compose.material.rememberDrawerState
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun NavigationDrawer(
+    scope: CoroutineScope,
+    scaffoldState: ScaffoldState,
+    navController: NavController
+) {
+    /* Using sealedSubclasses requires reflection, which will make the app slower,
+     * so list each drawer item manually
+     */
+    val drawerItems = listOf(
+        DrawerItem.Home
+    )
+
+    Column {
+        // Show the app logo at the top
+//        Image(
+//            painter = painterResource(R.mipmap.ic_launcher_foreground),
+//            contentDescription = stringResource(R.string.app_logo_alt),
+//            modifier = Modifier
+//                .height(100.dp)
+//                .fillMaxWidth()
+//                .padding(8.dp)
+//        )
+//        Spacer(
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .height(8.dp)
+//        )
+        // Loop through all the subclasses of the sealed DrawerItem class
+        drawerItems.forEach { item ->
+            // Show text that can be clicked on to navigate to the appropriate screen
+            ClickableText(
+                text = AnnotatedString(item.title),
+                onClick = {
+                    navController.navigate(item.route) {
+                        navController.graph.startDestinationRoute?.let { route ->
+                            popUpTo(route) {
+                                saveState = true
+                            }
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                    scope.launch {
+                        scaffoldState.drawerState.close()
+                    }
+                }
+            )
+        }
+    }
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+fun NavigationDrawerPreview() {
+    val scope = rememberCoroutineScope()
+    val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
+    val navController = rememberNavController()
+
+    EZRecipesTheme {
+        NavigationDrawer(scope, scaffoldState, navController)
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -64,13 +64,11 @@ fun NavigationDrawer(
                 selected = currentRoute == item.route,
                 onItemClick = {
                     navController.navigate(item.route) {
+                        // Pop all previous routes from the back stack until the selected route is found
                         navController.graph.startDestinationRoute?.let { route ->
-                            popUpTo(route) {
-                                saveState = true
-                            }
+                            popUpTo(route)
                         }
                         launchSingleTop = true
-                        restoreState = true
                     }
                     scope.launch {
                         scaffoldState.drawerState.close()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -1,27 +1,24 @@
-package com.abhiek.ezrecipes.ui
+package com.abhiek.ezrecipes.ui.navbar
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.ui.home.Home
 import com.abhiek.ezrecipes.ui.recipe.Recipe
-import com.abhiek.ezrecipes.utils.Constants
 import com.google.gson.Gson
 import java.net.URLEncoder
 
 @Composable
-fun NavigationGraph() {
-    // The navigation controller shouldn't be recreated in other composables
-    val navController = rememberNavController()
-
+fun NavigationGraph(navController: NavHostController) {
     // Show the appropriate composable based on the current route, starting at the home screen
+    // NavHostController is a subclass of NavController
     NavHost(
         navController = navController,
-        startDestination = Constants.Routes.HOME
+        startDestination = DrawerItem.Home.route
     ) {
-        composable(Constants.Routes.HOME) {
+        composable(DrawerItem.Home.route) {
             Home { recipe ->
                 // Store the recipe as a string in the route
                 val recipeJson = Gson().toJson(recipe)
@@ -31,14 +28,14 @@ fun NavigationGraph() {
                 encodedRecipeJson = encodedRecipeJson.replace("+", "%20")
 
                 navController.navigate(
-                    Constants.Routes.RECIPE.replace("{recipe}", encodedRecipeJson)
+                    DrawerItem.Recipe.route.replace("{recipe}", encodedRecipeJson)
                 ) {
                     // Only have one copy of the recipe destination in the back stack
                     launchSingleTop = true
                 }
             }
         }
-        composable(Constants.Routes.RECIPE) { backStackEntry ->
+        composable(DrawerItem.Recipe.route) { backStackEntry ->
             // Parse the recipe object from the route string
             val recipeJson = backStackEntry.arguments?.getString("recipe")
             val recipe = Gson().fromJson(recipeJson, Recipe::class.java)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -2,9 +2,11 @@ package com.abhiek.ezrecipes.ui.navbar
 
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
@@ -17,6 +19,8 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun TopBar(scope: CoroutineScope, scaffoldState: ScaffoldState) {
+    var isFavorite by remember { mutableStateOf(false) }
+
     TopAppBar(
         title = {
             Text(text = stringResource(R.string.app_name))
@@ -30,7 +34,19 @@ fun TopBar(scope: CoroutineScope, scaffoldState: ScaffoldState) {
                     }
                 }
             ) {
-                Icon(Icons.Filled.Menu, "Open menu")
+                Icon(Icons.Filled.Menu, stringResource(R.string.hamburger_menu_alt))
+            }
+        },
+        // Add a favorite and share button on the right side if we're on the recipe screen
+        actions = {
+            IconButton(onClick = { isFavorite = !isFavorite }) {
+                Icon(
+                    if (isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+                    if (isFavorite) stringResource(R.string.un_favorite_alt) else stringResource(R.string.favorite_alt)
+                )
+            }
+            IconButton(onClick = {}) {
+                Icon(Icons.Filled.Share, stringResource(R.string.share_alt))
             }
         },
         backgroundColor = MaterialTheme.colors.primary

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -1,5 +1,6 @@
 package com.abhiek.ezrecipes.ui.navbar
 
+import android.content.Intent
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
@@ -7,6 +8,7 @@ import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
@@ -20,6 +22,19 @@ import kotlinx.coroutines.launch
 @Composable
 fun TopBar(scope: CoroutineScope, scaffoldState: ScaffoldState) {
     var isFavorite by remember { mutableStateOf(false) }
+    // Get a context variable like in activities
+    val context = LocalContext.current
+
+    fun shareRecipe() {
+        // Create a Sharesheet to share the recipe with others
+        val sendIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_body))
+            type = "text/plain"
+        }
+        val shareIntent = Intent.createChooser(sendIntent, null)
+        context.startActivity(shareIntent)
+    }
 
     TopAppBar(
         title = {
@@ -45,7 +60,7 @@ fun TopBar(scope: CoroutineScope, scaffoldState: ScaffoldState) {
                     if (isFavorite) stringResource(R.string.un_favorite_alt) else stringResource(R.string.favorite_alt)
                 )
             }
-            IconButton(onClick = {}) {
+            IconButton(onClick = { shareRecipe() }) {
                 Icon(Icons.Filled.Share, stringResource(R.string.share_alt))
             }
         },

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -1,0 +1,52 @@
+package com.abhiek.ezrecipes.ui.navbar
+
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.res.stringResource
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun TopBar(scope: CoroutineScope, scaffoldState: ScaffoldState) {
+    TopAppBar(
+        title = {
+            Text(text = stringResource(R.string.app_name))
+        },
+        navigationIcon = {
+            // Show a hamburger menu in the top left
+            IconButton(
+                onClick = {
+                    scope.launch {
+                        scaffoldState.drawerState.open()
+                    }
+                }
+            ) {
+                Icon(Icons.Filled.Menu, "Open menu")
+            }
+        },
+        backgroundColor = MaterialTheme.colors.primary
+    )
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+fun TopBarPreview() {
+    val scope = rememberCoroutineScope()
+    val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
+
+    EZRecipesTheme {
+        TopBar(scope, scaffoldState)
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/previews/OrientationPreviews.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/previews/OrientationPreviews.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.tooling.preview.Preview
     name = "Landscape",
     group = "Orientations",
     device = Devices.AUTOMOTIVE_1024p,
-    widthDp = 1920,
-    heightDp = 1080,
+    widthDp = 1024,
+    heightDp = 632,
     showSystemUi = true
 )
 annotation class OrientationPreviews

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -10,10 +10,4 @@ object Constants {
 
     // Error message to fallback on in case all fails
     val UNKNOWN_ERROR = Resources.getSystem().getString(R.string.unknown_error)
-
-    // Routes in the navigation graph
-    object Routes {
-        const val HOME = "home"
-        const val RECIPE = "recipe/{recipe}"
-    }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -1,9 +1,15 @@
 package com.abhiek.ezrecipes.utils
 
+import android.content.res.Resources
+import com.abhiek.ezrecipes.R
+
 object Constants {
     // In Retrofit, base URLs must end with a /
     const val RECIPE_BASE_URL = "https://ez-recipes-server.onrender.com/api/recipes/"
     const val RANDOM_RECIPE_PATH = "random"
+
+    // Error message to fallback on in case all fails
+    val UNKNOWN_ERROR = Resources.getSystem().getString(R.string.unknown_error)
 
     // Routes in the navigation graph
     object Routes {

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="favorite_alt">Favorite this recipe</string>
     <string name="un_favorite_alt">Un-favorite this recipe</string>
     <string name="share_alt">Share this recipe</string>
+    <string name="share_body">Check out this low-effort recipe!</string>
 
     <!-- Home Screen -->
     <string name="find_recipe_button">Find Me a Recipe!</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <!-- App Bar -->
     <string name="app_name">EZ Recipes</string>
-    <string name="home_nav">Home</string>
+    <string name="app_logo_alt">Food cooking in a pot</string>
 
     <!-- Home Screen -->
     <string name="find_recipe_button">Find Me a Recipe!</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -2,6 +2,10 @@
     <!-- App Bar -->
     <string name="app_name">EZ Recipes</string>
     <string name="app_logo_alt">Food cooking in a pot</string>
+    <string name="hamburger_menu_alt">Open menu</string>
+    <string name="favorite_alt">Favorite this recipe</string>
+    <string name="un_favorite_alt">Un-favorite this recipe</string>
+    <string name="share_alt">Share this recipe</string>
 
     <!-- Home Screen -->
     <string name="find_recipe_button">Find Me a Recipe!</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -5,6 +5,12 @@
 
     <!-- Home Screen -->
     <string name="find_recipe_button">Find Me a Recipe!</string>
+    <string name="error_title">Error</string>
+    <string name="unknown_error">
+        Something went terribly wrong. Please submit a bug report to https://github.com/Abhiek187/ez-recipes-android/issues
+    </string>
+    <!-- Android strings: https://developer.android.com/reference/android/R.string -->
+    <string name="ok_button">@android:string/ok</string>
 
     <!-- Recipe Screen -->
     <string name="image_copyright">Image © %1$s</string>

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/RecipeRepositoryTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/RecipeRepositoryTest.kt
@@ -8,28 +8,60 @@ import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class RecipeRepositoryTest {
-    private lateinit var sut: RecipeRepository // system under test
+    private lateinit var mockService: MockRecipeService
+    private lateinit var recipeRepository: RecipeRepository
 
     @BeforeEach
     fun setUp() {
-        sut = RecipeRepository(MockRecipeService)
+        mockService = MockRecipeService
+        recipeRepository = RecipeRepository(mockService)
     }
 
     @Test
-    fun getRandomRecipe() = runTest {
+    fun getRandomRecipeSuccess() = runTest {
         // Given an instance of RecipeRepository
         // When the getRandomRecipe() method is called
+        mockService.isSuccess = true
+        val response = recipeRepository.getRandomRecipe()
+
         // Then it should return a successful response
-        val response = sut.getRandomRecipe()
-        assert(response.isSuccess)
+        assertTrue(response is RecipeResult.Success)
+        assertEquals((response as RecipeResult.Success).recipe, mockService.recipe)
     }
 
     @Test
-    fun getRecipeById() = runTest {
+    fun getRandomRecipeError() = runTest {
+        // Given an instance of RecipeRepository
+        // When the getRandomRecipe() method is called with isSuccess = false
+        mockService.isSuccess = false
+        val response = recipeRepository.getRandomRecipe()
+
+        // Then it should return an error
+        assertTrue(response is RecipeResult.Error)
+        assertEquals((response as RecipeResult.Error).recipeError, mockService.recipeError)
+    }
+
+    @Test
+    fun getRecipeByIdSuccess() = runTest {
         // Given an instance of RecipeRepository
         // When the getRecipeById() method is called
+        mockService.isSuccess = true
+        val response = recipeRepository.getRecipeById(1)
+
         // Then it should return a successful response
-        val response = sut.getRecipeById(1)
-        assert(response.isSuccess)
+        assertTrue(response is RecipeResult.Success)
+        assertEquals((response as RecipeResult.Success).recipe, mockService.recipe)
+    }
+
+    @Test
+    fun getRecipeByIdError() = runTest {
+        // Given an instance of RecipeRepository
+        // When the getRecipeById() method is called with isSuccess = false
+        mockService.isSuccess = false
+        val response = recipeRepository.getRecipeById(1)
+
+        // Then it should return an error response
+        assertTrue(response is RecipeResult.Error)
+        assertEquals((response as RecipeResult.Error).recipeError, mockService.recipeError)
     }
 }

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
@@ -12,28 +12,72 @@ import org.junit.jupiter.api.extension.ExtendWith
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MainDispatcherExtension::class)
 internal class MainViewModelTest {
-    private lateinit var sut: MainViewModel
+    private lateinit var mockService: MockRecipeService
+    private lateinit var viewModel: MainViewModel
 
     @BeforeEach
     fun setUp() {
-        sut = MainViewModel(RecipeRepository(MockRecipeService))
+        mockService = MockRecipeService
+        viewModel = MainViewModel(RecipeRepository(mockService))
     }
 
     @Test
-    fun getRandomRecipe() = runTest {
+    fun getRandomRecipeSuccess() = runTest {
         // Given an instance of MainViewModel
         // When the getRandomRecipe() method is called
+        mockService.isSuccess = true
+        viewModel.getRandomRecipe()
+
         // Then the recipe property should match the mock recipe
-        sut.getRandomRecipe()
-        assertEquals(sut.recipe, MockRecipeService.recipe)
+        assertEquals(viewModel.recipe, mockService.recipe)
+        assertNull(viewModel.recipeError)
+        assertFalse(viewModel.isLoading)
+        assertTrue(viewModel.isRecipeLoaded)
+        assertFalse(viewModel.showRecipeAlert)
     }
 
     @Test
-    fun getRecipeById() = runTest {
+    fun getRandomRecipeError() = runTest {
+        // Given an instance of MainViewModel
+        // When the getRandomRecipe() method is called with isSuccess = false
+        mockService.isSuccess = false
+        viewModel.getRandomRecipe()
+
+        // Then the recipeError property should match the mock recipeError
+        assertNull(viewModel.recipe)
+        assertEquals(viewModel.recipeError, mockService.recipeError)
+        assertFalse(viewModel.isLoading)
+        assertFalse(viewModel.isRecipeLoaded)
+        assertTrue(viewModel.showRecipeAlert)
+    }
+
+    @Test
+    fun getRecipeByIdSuccess() = runTest {
         // Given an instance of MainViewModel
         // When the getRecipeById() method is called
+        mockService.isSuccess = true
+        viewModel.getRecipeById(1)
+
         // Then the recipe property should match the mock recipe
-        sut.getRecipeById(1)
-        assertEquals(sut.recipe, MockRecipeService.recipe)
+        assertEquals(viewModel.recipe, mockService.recipe)
+        assertNull(viewModel.recipeError)
+        assertFalse(viewModel.isLoading)
+        assertTrue(viewModel.isRecipeLoaded)
+        assertFalse(viewModel.showRecipeAlert)
+    }
+
+    @Test
+    fun getRecipeByIdError() = runTest {
+        // Given an instance of MainViewModel
+        // When the getRecipeById() method is called with isSuccess = false
+        mockService.isSuccess = false
+        viewModel.getRecipeById(1)
+
+        // Then the recipeError property should match the mock recipeError
+        assertNull(viewModel.recipe)
+        assertEquals(viewModel.recipeError, mockService.recipeError)
+        assertFalse(viewModel.isLoading)
+        assertFalse(viewModel.isRecipeLoaded)
+        assertTrue(viewModel.showRecipeAlert)
     }
 }


### PR DESCRIPTION
<div>
  <img src="https://user-images.githubusercontent.com/29958092/204066520-11fa9eaa-82a7-4d6c-9b26-8ad69e3584d8.gif" alt="find-fail" width="300">
  <img src="https://user-images.githubusercontent.com/29958092/204066523-f9ca4a83-12da-4a60-9c1d-a3777b7cdd28.gif" alt="find-success" width="300">
  <img src="https://user-images.githubusercontent.com/29958092/204070160-18eeb9cb-0199-4715-a01f-12107beee09c.png" alt="share sheet" width="300">
</div>

_(To show a demo, I need to save the recording as a GIF, .webm isn't supported in markdown. Also, recording in landscape mode will require rotating the video since the emulator only records in portrait mode, for some reason.)_

Today was a more productive day on the Android side. I was able to display an alert whenever the API returned an error. And similar to iOS, I created a custom error result that holds the RecipeError object. I debated between using a Toast or Snackbar, similar to the web app, but I chose an alert to fit a longer error message. (And since it was easier to include than a Snackbar. 😜) Although, Retrofit's error messages are much terser compared to Alamofire's. For example, _not found_ for 404 errors and _timeout_ if the request takes longer than 30 seconds. Due to the nullability of these errors, I used the `UNKNOWN_ERROR` string quite a bit, which could result in several tickets coming my way in the future. 🥲 I also added failure tests for the ViewModel and Repository to check that the states are set properly for each scenario. This also extends to the previews, where I was able to use an `isSuccess` flag to easily test successful and unsuccessful calls in the UI.

For the navbar, I had to once again restructure my files to add the logic for the navigation drawer. Most of the "remember" variables had to be moved to the `MainLayout` composable with the Scaffold and passed to all the child composables. But a huge shoutout to [this StackOverflow post](https://stackoverflow.com/a/73295465) for explaining how to construct all the UI elements (and make it look neat)! Other than a few bugs in the previews, I didn't encounter as many issues as I did on day 3, so I'm glad it all worked out in the end. But man, that's a lot of files! Let's see how iOS compares. One thing I do want to try is adding more string constants as I did for `strings.xml`, instead of hardcoding them all.

One thing I learned in the process is how sealed classes work in Kotlin. They are like an extension of enum classes that allow you to create subclasses within that same file. For instance, I can create Success and Error classes that inherit from Result to represent either successful or unsuccessful API responses.

Also, while creating this PR, I decided to include the favorite and share icons on the top bar with similar functionality to the web app. I originally considered converting the recipe screen into a pdf, but it might be easier to share an app link to the recipe page. (Though it will prevent others who don't have the app from viewing the recipe.)