### PR TITLE
Android Day 5: Starting the recipe screen

### DIFF
--- a/EZRecipes/app/build.gradle
+++ b/EZRecipes/app/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended:1.3.1"
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'androidx.navigation:navigation-compose:2.5.3'
+    // AsyncImage
+    implementation 'io.coil-kt:coil-compose:2.2.2'
 
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/EZRecipes/app/build.gradle
+++ b/EZRecipes/app/build.gradle
@@ -54,8 +54,8 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.6.1'
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
-    implementation "androidx.compose.material:material:$compose_ui_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_ui_version"
+    implementation "androidx.compose.material:material:1.3.1"
+    implementation "androidx.compose.material:material-icons-extended:1.3.1"
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'androidx.navigation:navigation-compose:2.5.3'
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
@@ -17,7 +17,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
+fun IngredientsList(recipe: Recipe) {
     Text(
         text = recipe.name,
         fontSize = 24.sp,
@@ -32,10 +32,10 @@ fun Recipe(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipePreview() {
+fun IngredientsListPreview() {
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            IngredientsList(MockRecipeService.recipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/InstructionsList.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/InstructionsList.kt
@@ -17,7 +17,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
+fun InstructionsList(recipe: Recipe) {
     Text(
         text = recipe.name,
         fontSize = 24.sp,
@@ -32,10 +32,10 @@ fun Recipe(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipePreview() {
+fun InstructionsListPreview() {
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            InstructionsList(MockRecipeService.recipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/NutritionLabel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/NutritionLabel.kt
@@ -17,7 +17,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
+fun NutritionLabel(recipe: Recipe) {
     Text(
         text = recipe.name,
         fontSize = 24.sp,
@@ -32,10 +32,10 @@ fun Recipe(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipePreview() {
+fun NutritionLabelPreview() {
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            NutritionLabel(MockRecipeService.recipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -1,13 +1,15 @@
 package com.abhiek.ezrecipes.ui.recipe
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
 import androidx.compose.material.Surface
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.abhiek.ezrecipes.data.MockRecipeService
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
@@ -18,13 +20,23 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
 fun Recipe(recipe: Recipe) {
-    Text(
-        text = recipe.name,
-        fontSize = 24.sp,
-        textAlign = TextAlign.Center,
+    // Make the column scrollable
+    Column(
         modifier = Modifier
-            .padding(top = 8.dp)
-    )
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        RecipeHeader(recipe = recipe)
+        NutritionLabel(recipe = recipe)
+        SummaryBox(recipe = recipe)
+        IngredientsList(recipe = recipe)
+        InstructionsList(recipe = recipe)
+
+        Divider()
+
+        RecipeFooter()
+    }
 }
 
 @DevicePreviews

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
@@ -17,7 +17,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
+fun RecipeFooter(recipe: Recipe) {
     Text(
         text = recipe.name,
         fontSize = 24.sp,
@@ -32,10 +32,10 @@ fun Recipe(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipePreview() {
+fun RecipeFooterPreview() {
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            RecipeFooter(MockRecipeService.recipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
@@ -1,5 +1,6 @@
 package com.abhiek.ezrecipes.ui.recipe
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -20,10 +21,11 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 fun RecipeFooter() {
     Text(
         text = stringResource(R.string.attribution),
-        fontSize = 10.sp,
+        fontSize = 12.sp,
         textAlign = TextAlign.Center,
         modifier = Modifier
             .padding(vertical = 8.dp)
+            .fillMaxWidth()
     )
 }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
@@ -5,11 +5,11 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.abhiek.ezrecipes.data.MockRecipeService
-import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -17,13 +17,13 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun RecipeFooter(recipe: Recipe) {
+fun RecipeFooter() {
     Text(
-        text = recipe.name,
-        fontSize = 24.sp,
+        text = stringResource(R.string.attribution),
+        fontSize = 10.sp,
         textAlign = TextAlign.Center,
         modifier = Modifier
-            .padding(top = 8.dp)
+            .padding(vertical = 8.dp)
     )
 }
 
@@ -35,7 +35,7 @@ fun RecipeFooter(recipe: Recipe) {
 fun RecipeFooterPreview() {
     EZRecipesTheme {
         Surface {
-            RecipeFooter(MockRecipeService.recipe)
+            RecipeFooter()
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -1,30 +1,185 @@
 package com.abhiek.ezrecipes.ui.recipe
 
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.ReceiptLong
+import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.MockRecipeService
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.Blue300
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
 fun RecipeHeader(recipe: Recipe) {
-    Text(
-        text = recipe.name,
-        fontSize = 24.sp,
-        textAlign = TextAlign.Center,
-        modifier = Modifier
-            .padding(top = 8.dp)
-    )
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    val annotationTag = "URL"
+
+    // Make the image caption clickable
+    val annotatedLinkString = buildAnnotatedString {
+        val str = stringResource(R.string.image_copyright, recipe.credit ?: "")
+        val startIndex = 8 // "Image © ".length = 8
+        val endIndex = str.length // exclusive
+        append(str)
+
+        // Apply a blue link style to the section after the copyright symbol
+        addStyle(
+            style = SpanStyle(
+                color = Blue300,
+                fontSize = 12.sp,
+                textDecoration = TextDecoration.Underline
+            ),
+            start = startIndex,
+            end = endIndex
+        )
+
+        // Point the link to the source URL and tag it for reference
+        addStringAnnotation(
+            tag = annotationTag,
+            annotation = recipe.sourceUrl,
+            start = startIndex,
+            end = endIndex
+        )
+    }
+
+    val timeAnnotatedString = buildAnnotatedString {
+        val str = context.resources.getQuantityString(R.plurals.recipe_time, recipe.time, recipe.time)
+        val startIndex = 0
+        val endIndex = 5 // "Time:".length = 5
+        append(str)
+
+        // Bold only the time portion of the string
+        addStyle(
+            style = SpanStyle(
+                fontWeight = FontWeight.Bold
+            ),
+            start = startIndex,
+            end = endIndex
+        )
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            // Recipe name and source link
+            Text(
+                text = recipe.name,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(top = 8.dp)
+            )
+
+            IconButton(
+                onClick = { uriHandler.openUri(recipe.url) }
+            ) {
+                Icon(Icons.Default.Link, stringResource(R.string.recipe_link))
+            }
+        }
+
+        // Recipe image and caption
+        AsyncImage(
+            model = recipe.image,
+            contentDescription = recipe.name,
+            modifier = Modifier.size(300.dp)
+        )
+
+        if (recipe.credit != null) {
+            ClickableText(
+                text = annotatedLinkString,
+                style = TextStyle(
+                    color = MaterialTheme.colors.onBackground
+                ),
+                modifier = Modifier.padding(horizontal = 8.dp)
+            ) { offset ->
+                // Open the URL from the annotated string
+                annotatedLinkString
+                    .getStringAnnotations(annotationTag, offset, offset)
+                    .firstOrNull()?.let { stringAnnotation ->
+                        uriHandler.openUri(stringAnnotation.item)
+                    }
+            }
+        }
+
+        // Recipe time and buttons
+        Text(
+            text = timeAnnotatedString,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+        
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Button(
+                    modifier = Modifier.size(50.dp), // avoid the oval shape
+                    shape = CircleShape,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.colors.error
+                    ),
+                    onClick = { println("Nice! Hope it was tasty!") }
+                ) {
+                    Icon(Icons.Default.Restaurant, stringResource(R.string.made_button))
+                }
+                Text(
+                    text = stringResource(R.string.made_button),
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Button(
+                    modifier = Modifier.size(50.dp),
+                    shape = CircleShape,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.colors.secondary
+                    ),
+                    onClick = { println("Showing another recipe...") }
+                ) {
+                    Icon(Icons.Default.ReceiptLong, stringResource(R.string.show_recipe_button))
+                }
+                Text(
+                    text = stringResource(R.string.show_recipe_button),
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
 }
 
 @DevicePreviews

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -17,7 +17,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
+fun RecipeHeader(recipe: Recipe) {
     Text(
         text = recipe.name,
         fontSize = 24.sp,
@@ -32,10 +32,10 @@ fun Recipe(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipePreview() {
+fun RecipeHeaderPreview() {
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            RecipeHeader(MockRecipeService.recipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
@@ -17,7 +17,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
+fun StepCard(recipe: Recipe) {
     Text(
         text = recipe.name,
         fontSize = 24.sp,
@@ -32,10 +32,10 @@ fun Recipe(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipePreview() {
+fun StepCardPreview() {
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            StepCard(MockRecipeService.recipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
@@ -17,7 +17,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
+fun SummaryBox(recipe: Recipe) {
     Text(
         text = recipe.name,
         fontSize = 24.sp,
@@ -32,10 +32,10 @@ fun Recipe(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipePreview() {
+fun SummaryBoxPreview() {
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            SummaryBox(MockRecipeService.recipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="ok_button">@android:string/ok</string>
 
     <!-- Recipe Screen -->
+    <string name="recipe_link">Open recipe source</string>
     <string name="image_copyright">Image © %1$s</string>
 
     <plurals name="recipe_time">

--- a/EZRecipes/build.gradle
+++ b/EZRecipes/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
-        compose_ui_version = '1.3.1'
-        kotlin_compiler_version = '1.3.1'
-        kotlin_version = '1.7.10'
+        compose_ui_version = '1.3.2'
+        kotlin_compiler_version = '1.3.2'
+        kotlin_version = '1.7.20'
     }
 }
 


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/29958092/209610833-6fffc503-9e23-4c66-9db6-228581cf395e.png" alt="screenshot of recipe header" width="300">

I set up most of the recipe header (as well as the footer) today. Some adjustments will need to be made, but otherwise, it's looking pretty good so far! The styling matches the website more than the iOS app since Android and Angular are made by Google and built from Material Design. I do miss having the ability to render Markdown, but I made do with JC's annotated strings, and the links work as expected with the right formatting. For the image, I used [Coil](https://coil-kt.github.io/coil/compose/) to get a similar `AsyncImage` component from SwiftUI. I find it interesting how much easier it is to add alt text to these images here compared to iOS. SwiftUI seems to always treat async images as decorative, and adding alt text to other images is a little more cumbersome.

I added all the recipe composables I'll need as I make the recipe screen over these next few days. Hopefully, there won't be too many roadblocks along the way.