### PR TITLE
Android Day 7: Show Me the Recipe Page!

### DIFF
--- a/EZRecipes/app/build.gradle
+++ b/EZRecipes/app/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     implementation 'androidx.navigation:navigation-compose:2.5.3'
     // AsyncImage
     implementation 'io.coil-kt:coil-compose:2.2.2'
+    // Experimental utils for Jetpack Compose
+    implementation 'com.google.accompanist:accompanist-flowlayout:0.28.0'
 
     // Retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/MockRecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/MockRecipeService.kt
@@ -1,23 +1,12 @@
 package com.abhiek.ezrecipes.data
 
-import com.abhiek.ezrecipes.data.models.Recipe
-import com.abhiek.ezrecipes.data.models.RecipeError
-import com.google.gson.Gson
+import com.abhiek.ezrecipes.data.models.*
 import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 
 // Send hardcoded recipe responses for tests
 // Using an object to create a singleton to pass to the repository
 object MockRecipeService: RecipeService {
-    // Normal
-    private const val blueberryRecipeString = "{\"id\":635562,\"name\":\"Blueberry-Pineapple Salad\",\"url\":\"https://spoonacular.com/blueberry-pineapple-salad-635562\",\"image\":\"https://spoonacular.com/recipeImages/635562-312x231.jpg\",\"credit\":\"Foodista.com – The Cooking Encyclopedia Everyone Can Edit\",\"sourceUrl\":\"http://www.foodista.com/recipe/R84BP3YJ/blueberry-pineapple-salad\",\"healthScore\":1,\"time\":45,\"servings\":10,\"summary\":\"Blueberry-Pineapple Salad might be just the side dish you are searching for. For <b>93 cents per serving</b>, this recipe <b>covers 4%</b> of your daily requirements of vitamins and minerals. One serving contains <b>297 calories</b>, <b>2g of protein</b>, and <b>13g of fat</b>. If you have cream, sugar, milk, and a few other ingredients on hand, you can make it. 1 person has made this recipe and would make it again. It is a good option if you're following a <b>gluten free</b> diet. From preparation to the plate, this recipe takes approximately <b>45 minutes</b>. All things considered, we decided this recipe <b>deserves a spoonacular score of 19%</b>. This score is not so amazing. Try <a href=\\\"https://spoonacular.com/recipes/kale-blueberry-pineapple-salad-672624\\\">Kale Blueberry Pineapple Salad</a>, <a href=\\\"https://spoonacular.com/recipes/blueberry-cantaloupe-and-pineapple-salad-thesaladbar-496507\\\">Blueberry, Cantaloupe and Pineapple Salad #TheSaladBar</a>, and <a href=\\\"https://spoonacular.com/recipes/chicken-strawberry-blueberry-pineapple-salad-with-poppy-seed-dressing-603148\\\">Chicken Strawberry Blueberry Pineapple Salad With Poppy Seed Dressing</a> for similar recipes.\",\"nutrients\":[{\"name\":\"Calories\",\"amount\":299.3,\"unit\":\"kcal\"},{\"name\":\"Fat\",\"amount\":12.58,\"unit\":\"g\"},{\"name\":\"Saturated Fat\",\"amount\":6.93,\"unit\":\"g\"},{\"name\":\"Carbohydrates\",\"amount\":47.28,\"unit\":\"g\"},{\"name\":\"Fiber\",\"amount\":1.76,\"unit\":\"g\"},{\"name\":\"Sugar\",\"amount\":43.99,\"unit\":\"g\"},{\"name\":\"Protein\",\"amount\":2.58,\"unit\":\"g\"},{\"name\":\"Cholesterol\",\"amount\":36.54,\"unit\":\"mg\"},{\"name\":\"Sodium\",\"amount\":80.29,\"unit\":\"mg\"}],\"ingredients\":[{\"id\":9050,\"name\":\"blueberries\",\"amount\":1.5,\"unit\":\"ounces\"},{\"id\":9354,\"name\":\"canned pineapple\",\"amount\":0.1,\"unit\":\"can\"},{\"id\":10419172,\"name\":\"cherry gelatin\",\"amount\":0.1,\"unit\":\"large\"},{\"id\":1017,\"name\":\"cream cheese\",\"amount\":0.8,\"unit\":\"ounces\"},{\"id\":1077,\"name\":\"milk\",\"amount\":0.1,\"unit\":\"teaspoon\"},{\"id\":1056,\"name\":\"sour cream\",\"amount\":0.1,\"unit\":\"cup\"},{\"id\":19335,\"name\":\"sugar\",\"amount\":0.15,\"unit\":\"cups\"}],\"instructions\":[{\"name\":\"\",\"steps\":[{\"number\":1,\"step\":\"Drain liquid from fruit and add water or fruit juice to make 3 cups. Make gelatin with the 3 cups heated liquid. Chill. When it starts to set, add fruit.\",\"ingredients\":[{\"id\":1029016,\"name\":\"fruit juice\",\"image\":\"apple-juice.jpg\"},{\"id\":19177,\"name\":\"gelatin\",\"image\":\"gelatin-powder.jpg\"},{\"id\":9431,\"name\":\"fruit\",\"image\":\"mixed-fresh-fruit.jpg\"},{\"id\":14412,\"name\":\"water\",\"image\":\"water.png\"}],\"equipment\":[]},{\"number\":2,\"step\":\"Mix ingredients for topping and spread on set salad.\",\"ingredients\":[{\"id\":0,\"name\":\"spread\",\"image\":\"\"}],\"equipment\":[]},{\"number\":3,\"step\":\"Serves 8-10\",\"ingredients\":[],\"equipment\":[]}]}]}"
-    // Contains instruction name
-    private const val chocolateRecipeString = "{\"id\":644783,\"name\":\"Gluten And Dairy Free Chocolate Cupcakes\",\"url\":\"https://spoonacular.com/gluten-and-dairy-free-chocolate-cupcakes-644783\",\"image\":\"https://spoonacular.com/recipeImages/644783-312x231.jpg\",\"credit\":\"Foodista.com – The Cooking Encyclopedia Everyone Can Edit\",\"sourceUrl\":\"https://www.foodista.com/recipe/PDGXCHNP/gluten-and-dairy-free-chocolate-cupcakes\",\"healthScore\":3,\"time\":45,\"servings\":4,\"summary\":\"The recipe Gluten And Dairy Free Chocolate Cupcakes can be made <b>in approximately about 45 minutes</b>. One serving contains <b>919 calories</b>, <b>15g of protein</b>, and <b>52g of fat</b>. This gluten free and fodmap friendly recipe serves 4 and costs <b>\$2.23 per serving</b>. It works well as a budget friendly dessert. Not a lot of people made this recipe, and 1 would say it hit the spot. Head to the store and pick up cocoa, xanthan gum, baking soda, and a few other things to make it today. This recipe is typical of American cuisine. It is brought to you by Foodista. Overall, this recipe earns a <b>rather bad spoonacular score of 23%</b>. Similar recipes are <a href=\\\"https://spoonacular.com/recipes/gluten-free-dairy-free-chocolate-zucchini-cupcakes-557465\\\">Gluten Free Dairy Free Chocolate Zucchini Cupcakes</a>, <a href=\\\"https://spoonacular.com/recipes/grain-free-gluten-free-and-dairy-free-spiced-applesauce-cupcakes-615243\\\">Grain-free, Gluten-free and Dairy-free Spiced Applesauce Cupcakes</a>, and <a href=\\\"https://spoonacular.com/recipes/gluten-free-chocolate-cupcakes-made-with-garbanzo-bean-flour-my-best-gluten-free-cupcakes-to-date-518499\\\">Gluten-Free Chocolate Cupcakes Made With Garbanzo Bean Flour – My Best Gluten-Free Cupcakes To Date</a>.\",\"nutrients\":[{\"name\":\"Calories\",\"amount\":918.45,\"unit\":\"kcal\"},{\"name\":\"Fat\",\"amount\":52.47,\"unit\":\"g\"},{\"name\":\"Saturated Fat\",\"amount\":31.75,\"unit\":\"g\"},{\"name\":\"Carbohydrates\",\"amount\":108.17,\"unit\":\"g\"},{\"name\":\"Fiber\",\"amount\":12.57,\"unit\":\"g\"},{\"name\":\"Sugar\",\"amount\":74.85,\"unit\":\"g\"},{\"name\":\"Protein\",\"amount\":14.53,\"unit\":\"g\"},{\"name\":\"Cholesterol\",\"amount\":279.85,\"unit\":\"mg\"},{\"name\":\"Sodium\",\"amount\":916.11,\"unit\":\"mg\"}],\"ingredients\":[{\"id\":93747,\"name\":\"coconut flour\",\"amount\":0.13,\"unit\":\"cup\"},{\"id\":93696,\"name\":\"tapioca flour\",\"amount\":0.13,\"unit\":\"cup\"},{\"id\":18372,\"name\":\"baking soda\",\"amount\":0.25,\"unit\":\"teaspoon\"},{\"id\":2047,\"name\":\"salt\",\"amount\":0.13,\"unit\":\"teaspoon\"},{\"id\":93626,\"name\":\"xanthan gum\",\"amount\":0.13,\"unit\":\"teaspoon\"},{\"id\":19165,\"name\":\"cocoa\",\"amount\":0.13,\"unit\":\"cup\"},{\"id\":14412,\"name\":\"water\",\"amount\":0.25,\"unit\":\"cup\"},{\"id\":1123,\"name\":\"eggs\",\"amount\":1.25,\"unit\":\"\"},{\"id\":2050,\"name\":\"vanilla\",\"amount\":0.25,\"unit\":\"tablespoon\"},{\"id\":1001,\"name\":\"butter\",\"amount\":2.5,\"unit\":\"tablespoons\"},{\"id\":19335,\"name\":\"sugar\",\"amount\":0.25,\"unit\":\"cup\"},{\"id\":98848,\"name\":\"dairy free chocolate chips\",\"amount\":0.25,\"unit\":\"cup\"},{\"id\":98976,\"name\":\"coconut creamer\",\"amount\":0.13,\"unit\":\"cup\"},{\"id\":14214,\"name\":\"instant coffee\",\"amount\":0.5,\"unit\":\"teaspoons\"}],\"instructions\":[{\"name\":\"\",\"steps\":[{\"number\":1,\"step\":\"Preheat oven to 375 degrees.\",\"ingredients\":[],\"equipment\":[{\"id\":404784,\"name\":\"oven\",\"image\":\"oven.jpg\"}]},{\"number\":2,\"step\":\"Bring the water to a boil. Stir in the cocoa until melted and set aside until it comes to room temperature.\",\"ingredients\":[{\"id\":19165,\"name\":\"cocoa powder\",\"image\":\"cocoa-powder.png\"},{\"id\":14412,\"name\":\"water\",\"image\":\"water.png\"}],\"equipment\":[]},{\"number\":3,\"step\":\"Stir together the coconut flour, cornstarch, xanthan gum, salt, and soda.\",\"ingredients\":[{\"id\":93747,\"name\":\"coconut flour\",\"image\":\"coconut-flour-or-other-gluten-free-flour.jpg\"},{\"id\":93626,\"name\":\"xanthan gum\",\"image\":\"white-powder.jpg\"},{\"id\":20027,\"name\":\"corn starch\",\"image\":\"white-powder.jpg\"},{\"id\":2047,\"name\":\"salt\",\"image\":\"salt.jpg\"},{\"id\":0,\"name\":\"pop\",\"image\":\"\"}],\"equipment\":[]},{\"number\":4,\"step\":\"Mix together well. If you have a sifter go ahead and sift it to get out all the clumps. You don't want to bite into your cupcake and get a clump of coconut flour. I don't have a sifter so I used my hands to de-clump the flour the best I can.\",\"ingredients\":[{\"id\":93747,\"name\":\"coconut flour\",\"image\":\"coconut-flour-or-other-gluten-free-flour.jpg\"},{\"id\":18139,\"name\":\"cupcakes\",\"image\":\"plain-cupcake.jpg\"},{\"id\":20081,\"name\":\"all purpose flour\",\"image\":\"flour.png\"}],\"equipment\":[{\"id\":404708,\"name\":\"sifter\",\"image\":\"sifter.jpg\"}]},{\"number\":5,\"step\":\"Beat together the butter and sugar.\",\"ingredients\":[{\"id\":1001,\"name\":\"butter\",\"image\":\"butter-sliced.jpg\"},{\"id\":19335,\"name\":\"sugar\",\"image\":\"sugar-in-bowl.png\"}],\"equipment\":[]},{\"number\":6,\"step\":\"Beat in the eggs, one at a time, then the vanilla. Scraping down the bowl as necessary.\",\"ingredients\":[{\"id\":1052050,\"name\":\"vanilla\",\"image\":\"vanilla.jpg\"},{\"id\":1123,\"name\":\"egg\",\"image\":\"egg.png\"}],\"equipment\":[{\"id\":404783,\"name\":\"bowl\",\"image\":\"bowl.jpg\"}]},{\"number\":7,\"step\":\"Add the flour mixture and beat until incorporated. Again, you might need to scrape down the bowl.\",\"ingredients\":[{\"id\":20081,\"name\":\"all purpose flour\",\"image\":\"flour.png\"}],\"equipment\":[{\"id\":404783,\"name\":\"bowl\",\"image\":\"bowl.jpg\"}]},{\"number\":8,\"step\":\"Add in the cocoa mixture and beat until smooth. Batter will be thin.\",\"ingredients\":[{\"id\":19165,\"name\":\"cocoa powder\",\"image\":\"cocoa-powder.png\"}],\"equipment\":[]},{\"number\":9,\"step\":\"Line a muffin tin with baking cups or spray generously with oil.\",\"ingredients\":[{\"id\":4582,\"name\":\"cooking oil\",\"image\":\"vegetable-oil.jpg\"}],\"equipment\":[{\"id\":404671,\"name\":\"muffin tray\",\"image\":\"muffin-tray.jpg\"}]},{\"number\":10,\"step\":\"Fill each cup almost to the top and bake 16-20 minutes, or until a toothpick inserted in the middle of muffin comes out clean.\",\"ingredients\":[],\"equipment\":[{\"id\":404644,\"name\":\"toothpicks\",\"image\":\"toothpicks.jpg\"},{\"id\":404784,\"name\":\"oven\",\"image\":\"oven.jpg\"}]}]},{\"name\":\"Lets make the ganache icing\",\"steps\":[{\"number\":1,\"step\":\"Place chocolate chips and instant coffee in a medium sized bowl.\",\"ingredients\":[{\"id\":99278,\"name\":\"chocolate chips\",\"image\":\"chocolate-chips.jpg\"},{\"id\":14214,\"name\":\"instant coffee\",\"image\":\"instant-coffee-or-instant-espresso.png\"}],\"equipment\":[{\"id\":404783,\"name\":\"bowl\",\"image\":\"bowl.jpg\"}]},{\"number\":2,\"step\":\"Heat the creamer over medium heat until it reaches a gentle boil.\",\"ingredients\":[{\"id\":0,\"name\":\"coffee creamer\",\"image\":\"\"}],\"equipment\":[]},{\"number\":3,\"step\":\"Pour the warm creamer over the chocolate and coffee, whisk until smooth.\",\"ingredients\":[{\"id\":19081,\"name\":\"chocolate\",\"image\":\"milk-chocolate.jpg\"},{\"id\":0,\"name\":\"coffee creamer\",\"image\":\"\"},{\"id\":14209,\"name\":\"coffee\",\"image\":\"brewed-coffee.jpg\"}],\"equipment\":[{\"id\":404661,\"name\":\"whisk\",\"image\":\"whisk.png\"}]},{\"number\":4,\"step\":\"Dip the top of the cupcakes in the ganache and place in refrigerator until set- 30-60 minutes.\",\"ingredients\":[{\"id\":18139,\"name\":\"cupcakes\",\"image\":\"plain-cupcake.jpg\"},{\"id\":0,\"name\":\"dip\",\"image\":\"\"}],\"equipment\":[]}]}]}"
-    val recipe: Recipe = Gson().fromJson(chocolateRecipeString, Recipe::class.java)
-
-    private const val recipeErrorString = "{\"error\":\"You are not authorized. Please read https://spoonacular.com/food-api/docs#Authentication\"}"
-    val recipeError: RecipeError = Gson().fromJson(recipeErrorString, RecipeError::class.java)
-
     var isSuccess = true // controls whether the mock API calls succeed or fail
 
     override suspend fun getRandomRecipe(): Response<Recipe> {
@@ -35,4 +24,297 @@ object MockRecipeService: RecipeService {
             Response.error(401, recipeErrorString.toResponseBody())
         }
     }
+
+    /*
+    //region Normal
+    val recipe = Recipe(
+        id = 635562,
+        name = "Blueberry-Pineapple Salad",
+        url = "https://spoonacular.com/blueberry-pineapple-salad-635562",
+        image = "https://spoonacular.com/recipeImages/635562-312x231.jpg",
+        credit = "Foodista.com – The Cooking Encyclopedia Everyone Can Edit",
+        sourceUrl = "http://www.foodista.com/recipe/R84BP3YJ/blueberry-pineapple-salad",
+        healthScore = 1,
+        time = 45,
+        servings = 10,
+        summary = "Blueberry-Pineapple Salad might be just the side dish you are searching for. For <b>93 cents per serving</b>, this recipe <b>covers 4%</b> of your daily requirements of vitamins and minerals. One serving contains <b>297 calories</b>, <b>2g of protein</b>, and <b>13g of fat</b>. If you have cream, sugar, milk, and a few other ingredients on hand, you can make it. 1 person has made this recipe and would make it again. It is a good option if you're following a <b>gluten free</b> diet. From preparation to the plate, this recipe takes approximately <b>45 minutes</b>. All things considered, we decided this recipe <b>deserves a spoonacular score of 19%</b>. This score is not so amazing. Try <a href=\"https://spoonacular.com/recipes/kale-blueberry-pineapple-salad-672624\">Kale Blueberry Pineapple Salad</a>, <a href=\"https://spoonacular.com/recipes/blueberry-cantaloupe-and-pineapple-salad-thesaladbar-496507\">Blueberry, Cantaloupe and Pineapple Salad #TheSaladBar</a>, and <a href=\"https://spoonacular.com/recipes/chicken-strawberry-blueberry-pineapple-salad-with-poppy-seed-dressing-603148\">Chicken Strawberry Blueberry Pineapple Salad With Poppy Seed Dressing</a> for similar recipes.",
+        nutrients = listOf(
+            Nutrient(name = "Calories", amount = 299.3, unit = "kcal"),
+            Nutrient(name = "Fat", amount = 12.58, unit = "g"),
+            Nutrient(name = "Saturated Fat", amount = 6.93, unit = "g"),
+            Nutrient(name = "Carbohydrates", amount = 47.28, unit = "g"),
+            Nutrient(name = "Fiber", amount = 1.76, unit = "g"),
+            Nutrient(name = "Sugar", amount = 43.99, unit = "g"),
+            Nutrient(name = "Protein", amount = 2.58, unit = "g"),
+            Nutrient(name = "Cholesterol", amount = 36.54, unit = "mg"),
+            Nutrient(name = "Sodium", amount = 80.29, unit = "mg")
+        ),
+        ingredients = listOf(
+            Ingredient(
+                id = 9050,
+                name = "blueberries",
+                amount = 1.5,
+                unit = "ounces"
+            ),
+            Ingredient(id = 9354, name = "canned pineapple", amount = 0.1, unit = "can"),
+            Ingredient(id = 10419172, name = "cherry gelatin", amount = 0.1, unit = "large"),
+            Ingredient(id = 1017, name = "cream cheese", amount = 0.8, unit = "ounces"),
+            Ingredient(id = 1077, name = "milk", amount = 0.1, unit = "teaspoon"),
+            Ingredient(id = 1056, name = "sour cream", amount = 0.1, unit = "cup"),
+            Ingredient(id = 19335, name = "sugar", amount = 0.15, unit = "cups")
+        ),
+        instructions = listOf(
+            Instruction(
+                name = "",
+                steps = listOf(
+                    Step(
+                        number = 1,
+                        step = "Drain liquid from fruit and add water or fruit juice to make 3 cups. Make gelatin with the 3 cups heated liquid. Chill. When it starts to set, add fruit.",
+                        ingredients = listOf(
+                            StepItem(
+                                id = 1029016,
+                                name = "fruit juice",
+                                image = "apple-juice.jpg"
+                            ),
+                            StepItem(id = 19177, name = "gelatin", image = "gelatin-powder.jpg"),
+                            StepItem(id = 9431, name = "fruit", image = "mixed-fresh-fruit.jpg"),
+                            StepItem(id = 14412, name = "water", image = "water.png")
+                        ),
+                        equipment = listOf()
+                    ),
+                    Step(
+                        number = 2,
+                        step = "Mix ingredients for topping and spread on set salad.",
+                        ingredients = listOf(StepItem(id = 0, name = "spread", image = "")),
+                        equipment = listOf()
+                    ),
+                    Step(
+                        number = 3,
+                        step = "Serves 8-10",
+                        ingredients = listOf(),
+                        equipment = listOf()
+                    )
+                )
+            )
+        )
+    )
+    //endregion
+    */
+    //region Contains instruction name
+    val recipe = Recipe(
+        id = 644783,
+        name = "Gluten And Dairy Free Chocolate Cupcakes",
+        url = "https://spoonacular.com/gluten-and-dairy-free-chocolate-cupcakes-644783",
+        image = "https://spoonacular.com/recipeImages/644783-312x231.jpg",
+        credit = "Foodista.com – The Cooking Encyclopedia Everyone Can Edit",
+        sourceUrl = "https://www.foodista.com/recipe/PDGXCHNP/gluten-and-dairy-free-chocolate-cupcakes",
+        healthScore = 3,
+        time = 45,
+        servings = 4,
+        summary = "The recipe Gluten And Dairy Free Chocolate Cupcakes can be made <b>in approximately about 45 minutes</b>. One serving contains <b>919 calories</b>, <b>15g of protein</b>, and <b>52g of fat</b>. This gluten free and fodmap friendly recipe serves 4 and costs <b>$2.23 per serving</b>. It works well as a budget friendly dessert. Not a lot of people made this recipe, and 1 would say it hit the spot. Head to the store and pick up cocoa, xanthan gum, baking soda, and a few other things to make it today. This recipe is typical of American cuisine. It is brought to you by Foodista. Overall, this recipe earns a <b>rather bad spoonacular score of 23%</b>. Similar recipes are <a href=\"https://spoonacular.com/recipes/gluten-free-dairy-free-chocolate-zucchini-cupcakes-557465\">Gluten Free Dairy Free Chocolate Zucchini Cupcakes</a>, <a href=\"https://spoonacular.com/recipes/grain-free-gluten-free-and-dairy-free-spiced-applesauce-cupcakes-615243\">Grain-free, Gluten-free and Dairy-free Spiced Applesauce Cupcakes</a>, and <a href=\"https://spoonacular.com/recipes/gluten-free-chocolate-cupcakes-made-with-garbanzo-bean-flour-my-best-gluten-free-cupcakes-to-date-518499\">Gluten-Free Chocolate Cupcakes Made With Garbanzo Bean Flour – My Best Gluten-Free Cupcakes To Date</a>.",
+        nutrients = listOf(
+            Nutrient(name = "Calories", amount = 918.45, unit = "kcal"),
+            Nutrient(name = "Fat", amount = 52.47, unit = "g"),
+            Nutrient(name = "Saturated Fat", amount = 31.75, unit = "g"),
+            Nutrient(name = "Carbohydrates", amount = 108.17, unit = "g"),
+            Nutrient(name = "Fiber", amount = 12.57, unit = "g"),
+            Nutrient(name = "Sugar", amount = 74.85, unit = "g"),
+            Nutrient(name = "Protein", amount = 14.53, unit = "g"),
+            Nutrient(name = "Cholesterol", amount = 279.85, unit = "mg"),
+            Nutrient(name = "Sodium", amount = 916.11, unit = "mg")
+        ),
+        ingredients = listOf(
+            Ingredient(id = 93747, name = "coconut flour", amount = 0.13, unit = "cup"),
+            Ingredient(id = 93696, name = "tapioca flour", amount = 0.13, unit = "cup"),
+            Ingredient(id = 18372, name = "baking soda", amount = 0.25, unit = "teaspoon"),
+            Ingredient(id = 2047, name = "salt", amount = 0.13, unit = "teaspoon"),
+            Ingredient(id = 93626, name = "xanthan gum", amount = 0.13, unit = "teaspoon"),
+            Ingredient(id = 19165, name = "cocoa", amount = 0.13, unit = "cup"),
+            Ingredient(id = 14412, name = "water", amount = 0.25, unit = "cup"),
+            Ingredient(id = 1123, name = "eggs", amount = 1.25, unit = ""),
+            Ingredient(id = 2050, name = "vanilla", amount = 0.25, unit = "tablespoon"),
+            Ingredient(id = 1001, name = "butter", amount = 2.5, unit = "tablespoons"),
+            Ingredient(id = 19335, name = "sugar", amount = 0.25, unit = "cup"),
+            Ingredient(
+                id = 98848,
+                name = "dairy free chocolate chips",
+                amount = 0.25,
+                unit = "cup"
+            ),
+            Ingredient(id = 98976, name = "coconut creamer", amount = 0.13, unit = "cup"),
+            Ingredient(id = 14214, name = "instant coffee", amount = 0.5, unit = "teaspoons")
+        ),
+        instructions = listOf(
+            Instruction(
+                name = "",
+                steps = listOf(
+                    Step(
+                        number = 1,
+                        step = "Preheat oven to 375 degrees.",
+                        ingredients = listOf(),
+                        equipment = listOf(
+                            StepItem(id = 404784, name = "oven", image = "oven.jpg")
+                        )
+                    ),
+                    Step(
+                        number = 2,
+                        step = "Bring the water to a boil. Stir in the cocoa until melted and set aside until it comes to room temperature.",
+                        ingredients = listOf(
+                            StepItem(id = 19165, name = "cocoa powder", image = "cocoa-powder.png"),
+                            StepItem(id = 14412, name = "water", image = "water.png")
+                        ),
+                        equipment = listOf()
+                    ),
+                    Step(
+                        number = 3,
+                        step = "Stir together the coconut flour, cornstarch, xanthan gum, salt, and soda.",
+                        ingredients = listOf(
+                            StepItem(
+                                id = 93747,
+                                name = "coconut flour",
+                                image = "coconut-flour-or-other-gluten-free-flour.jpg"
+                            ),
+                            StepItem(id = 93626, name = "xanthan gum", image = "white-powder.jpg"),
+                            StepItem(id = 20027, name = "corn starch", image = "white-powder.jpg"),
+                            StepItem(id = 2047, name = "salt", image = "salt.jpg"),
+                            StepItem(id = 0, name = "pop", image = "")
+                        ),
+                        equipment = listOf()
+                    ),
+                    Step(
+                        number = 4,
+                        step = "Mix together well. If you have a sifter go ahead and sift it to get out all the clumps. You don't want to bite into your cupcake and get a clump of coconut flour. I don't have a sifter so I used my hands to de-clump the flour the best I can.",
+                        ingredients = listOf(
+                            StepItem(
+                                id = 93747,
+                                name = "coconut flour",
+                                image = "coconut-flour-or-other-gluten-free-flour.jpg"
+                            ),
+                            StepItem(id = 18139, name = "cupcakes", image = "plain-cupcake.jpg"),
+                            StepItem(id = 20081, name = "all purpose flour", image = "flour.png")
+                        ),
+                        equipment = listOf(
+                            StepItem(id = 404708, name = "sifter", image = "sifter.jpg")
+                        )
+                    ),
+                    Step(
+                        number = 5,
+                        step = "Beat together the butter and sugar.",
+                        ingredients = listOf(
+                            StepItem(id = 1001, name = "butter", image = "butter-sliced.jpg"),
+                            StepItem(id = 19335, name = "sugar", image = "sugar-in-bowl.png")
+                        ),
+                        equipment = listOf()
+                    ),
+                    Step(
+                        number = 6,
+                        step = "Beat in the eggs, one at a time, then the vanilla. Scraping down the bowl as necessary.",
+                        ingredients = listOf(
+                            StepItem(id = 1052050, name = "vanilla", image = "vanilla.jpg"),
+                            StepItem(id = 1123, name = "egg", image = "egg.png")
+                        ),
+                        equipment = listOf(
+                            StepItem(id = 404783, name = "bowl", image = "bowl.jpg")
+                        )
+                    ),
+                    Step(
+                        number = 7,
+                        step = "Add the flour mixture and beat until incorporated. Again, you might need to scrape down the bowl.",
+                        ingredients = listOf(
+                            StepItem(id = 20081, name = "all purpose flour", image = "flour.png")
+                        ),
+                        equipment = listOf(
+                            StepItem(id = 404783, name = "bowl", image = "bowl.jpg")
+                        )
+                    ),
+                    Step(
+                        number = 8,
+                        step = "Add in the cocoa mixture and beat until smooth. Batter will be thin.",
+                        ingredients = listOf(
+                            StepItem(id = 19165, name = "cocoa powder", image = "cocoa-powder.png")
+                        ),
+                        equipment = listOf()
+                    ),
+                    Step(
+                        number = 9,
+                        step = "Line a muffin tin with baking cups or spray generously with oil.",
+                        ingredients = listOf(
+                            StepItem(id = 4582, name = "cooking oil", image = "vegetable-oil.jpg")
+                        ),
+                        equipment = listOf(
+                            StepItem(id = 404671, name = "muffin tray", image = "muffin-tray.jpg")
+                        )
+                    ),
+                    Step(
+                        number = 10,
+                        step = "Fill each cup almost to the top and bake 16-20 minutes, or until a toothpick inserted in the middle of muffin comes out clean.",
+                        ingredients = listOf(),
+                        equipment = listOf(
+                            StepItem(id = 404644, name = "toothpicks", image = "toothpicks.jpg"),
+                            StepItem(id = 404784, name = "oven", image = "oven.jpg")
+                        )
+                    )
+                )
+            ),
+            Instruction(
+                name = "Lets make the ganache icing",
+                steps = listOf(
+                    Step(
+                        number = 1,
+                        step = "Place chocolate chips and instant coffee in a medium sized bowl.",
+                        ingredients = listOf(
+                            StepItem(
+                                id = 99278,
+                                name = "chocolate chips",
+                                image = "chocolate-chips.jpg"
+                            ),
+                            StepItem(
+                                id = 14214,
+                                name = "instant coffee",
+                                image = "instant-coffee-or-instant-espresso.png"
+                            )
+                        ),
+                        equipment = listOf(
+                            StepItem(id = 404783, name = "bowl", image = "bowl.jpg")
+                        )
+                    ),
+                    Step(
+                        number = 2,
+                        step = "Heat the creamer over medium heat until it reaches a gentle boil.",
+                        ingredients = listOf(
+                            StepItem(id = 0, name = "coffee creamer", image = "")
+                        ),
+                        equipment = listOf()
+                    ),
+                    Step(
+                        number = 3,
+                        step = "Pour the warm creamer over the chocolate and coffee, whisk until smooth.",
+                        ingredients = listOf(
+                            StepItem(id = 19081, name = "chocolate", image = "milk-chocolate.jpg"),
+                            StepItem(id = 0, name = "coffee creamer", image = ""),
+                            StepItem(id = 14209, name = "coffee", image = "brewed-coffee.jpg")
+                        ),
+                        equipment = listOf(
+                            StepItem(id = 404661, name = "whisk", image = "whisk.png")
+                        )
+                    ),
+                    Step(
+                        number = 4,
+                        step = "Dip the top of the cupcakes in the ganache and place in refrigerator until set- 30-60 minutes.",
+                        ingredients = listOf(
+                            StepItem(id = 18139, name = "cupcakes", image = "plain-cupcake.jpg"),
+                            StepItem(id = 0, name = "dip", image = "")
+                        ),
+                        equipment = listOf()
+                    )
+                )
+            )
+        )
+    )
+    //endregion
+
+    private const val recipeErrorString =
+        "{\"error\":\"You are not authorized. Please read https://spoonacular.com/food-api/docs#Authentication\"}"
+    val recipeError =
+        RecipeError(error = "You are not authorized. Please read https://spoonacular.com/food-api/docs#Authentication")
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -22,52 +22,48 @@ class MainViewModel(
         private set
 
     var isLoading by mutableStateOf(false)
+    // Alerts the home screen to navigate to the recipe screen
     var isRecipeLoaded by mutableStateOf(false)
     var showRecipeAlert by mutableStateOf(false)
 
-    fun getRandomRecipe() {
+    private fun updateRecipeProps(
+        response: RecipeResult,
+        fromHome: Boolean
+    ) {
+        // Set all the ViewModel properties based on the API result
+        when (response) {
+            is RecipeResult.Success -> {
+                recipe = response.recipe
+                recipeError = null
+                isRecipeLoaded = fromHome
+                showRecipeAlert = false
+            }
+            is RecipeResult.Error -> {
+                recipe = null
+                recipeError = response.recipeError
+                isRecipeLoaded = false
+                showRecipeAlert = true
+            }
+        }
+    }
+
+    fun getRandomRecipe(fromHome: Boolean = false) {
         viewModelScope.launch {
             isLoading = true
             val response = recipeRepository.getRandomRecipe()
             isLoading = false
 
-            when (response) {
-                is RecipeResult.Success -> {
-                    recipe = response.recipe
-                    recipeError = null
-                    isRecipeLoaded = true
-                    showRecipeAlert = false
-                }
-                is RecipeResult.Error -> {
-                    recipe = null
-                    recipeError = response.recipeError
-                    isRecipeLoaded = false
-                    showRecipeAlert = true
-                }
-            }
+            updateRecipeProps(response, fromHome)
         }
     }
 
-    fun getRecipeById(id: Int) {
+    fun getRecipeById(id: Int, fromHome: Boolean = false) {
         viewModelScope.launch {
             isLoading = true
             val response = recipeRepository.getRecipeById(id)
             isLoading = false
 
-            when (response) {
-                is RecipeResult.Success -> {
-                    recipe = response.recipe
-                    recipeError = null
-                    isRecipeLoaded = true
-                    showRecipeAlert = false
-                }
-                is RecipeResult.Error -> {
-                    recipe = null
-                    recipeError = response.recipeError
-                    isRecipeLoaded = false
-                    showRecipeAlert = true
-                }
-            }
+            updateRecipeProps(response, fromHome)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.MockRecipeService
 import com.abhiek.ezrecipes.data.RecipeRepository
-import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -25,14 +24,14 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 @Composable
 fun Home(
     mainViewModel: MainViewModel,
-    onNavigateToRecipe: (recipe: Recipe) -> Unit
+    onNavigateToRecipe: () -> Unit
 ) {
     // Go to the recipe screen after fetching it from the server
     // Don't call this when navigating back
     if (mainViewModel.isRecipeLoaded) {
         LaunchedEffect(mainViewModel.recipe) {
-            mainViewModel.recipe?.let { recipe ->
-                onNavigateToRecipe(recipe)
+            if (mainViewModel.recipe != null) {
+                onNavigateToRecipe()
                 mainViewModel.isRecipeLoaded = false
             }
         }
@@ -45,7 +44,7 @@ fun Home(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Button(
-            onClick = { mainViewModel.getRandomRecipe() },
+            onClick = { mainViewModel.getRandomRecipe(fromHome = true) },
             colors = ButtonDefaults.buttonColors(
                 backgroundColor = MaterialTheme.colors.secondary
             ),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -11,13 +11,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.MockRecipeService
 import com.abhiek.ezrecipes.data.RecipeRepository
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.ui.MainViewModel
-import com.abhiek.ezrecipes.ui.MainViewModelFactory
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -26,9 +24,7 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
 fun Home(
-    mainViewModel: MainViewModel = viewModel(
-        factory = MainViewModelFactory()
-    ),
+    mainViewModel: MainViewModel,
     onNavigateToRecipe: (recipe: Recipe) -> Unit
 ) {
     // Go to the recipe screen after fetching it from the server

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerItem.kt
@@ -9,5 +9,5 @@ import androidx.compose.ui.graphics.vector.ImageVector
 sealed class DrawerItem(val route: String, val title: String, val icon: ImageVector) {
     // Icons: https://fonts.google.com/icons (some require material-icons-extended)
     object Home: DrawerItem("home", "Home", Icons.Filled.Home)
-    object Recipe: DrawerItem("recipe/{recipe}", "Recipe", Icons.Filled.MenuBook)
+    object Recipe: DrawerItem("recipe", "Recipe", Icons.Filled.MenuBook)
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -1,10 +1,13 @@
 package com.abhiek.ezrecipes.ui.navbar
 
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.ui.MainViewModel
+import com.abhiek.ezrecipes.ui.MainViewModelFactory
 import com.abhiek.ezrecipes.ui.home.Home
 import com.abhiek.ezrecipes.ui.recipe.Recipe
 import com.google.gson.Gson
@@ -12,6 +15,10 @@ import java.net.URLEncoder
 
 @Composable
 fun NavigationGraph(navController: NavHostController) {
+    val viewModel: MainViewModel = viewModel(
+        factory = MainViewModelFactory()
+    )
+
     // Show the appropriate composable based on the current route, starting at the home screen
     // NavHostController is a subclass of NavController
     NavHost(
@@ -19,7 +26,7 @@ fun NavigationGraph(navController: NavHostController) {
         startDestination = DrawerItem.Home.route
     ) {
         composable(DrawerItem.Home.route) {
-            Home { recipe ->
+            Home(viewModel) { recipe ->
                 // Store the recipe as a string in the route
                 val recipeJson = Gson().toJson(recipe)
                 // Encode the string to prevent errors with parsing URLs
@@ -39,7 +46,7 @@ fun NavigationGraph(navController: NavHostController) {
             // Parse the recipe object from the route string
             val recipeJson = backStackEntry.arguments?.getString("recipe")
             val recipe = Gson().fromJson(recipeJson, Recipe::class.java)
-            Recipe(recipe)
+            Recipe(viewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -5,13 +5,10 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.MainViewModelFactory
 import com.abhiek.ezrecipes.ui.home.Home
 import com.abhiek.ezrecipes.ui.recipe.Recipe
-import com.google.gson.Gson
-import java.net.URLEncoder
 
 @Composable
 fun NavigationGraph(navController: NavHostController) {
@@ -26,26 +23,14 @@ fun NavigationGraph(navController: NavHostController) {
         startDestination = DrawerItem.Home.route
     ) {
         composable(DrawerItem.Home.route) {
-            Home(viewModel) { recipe ->
-                // Store the recipe as a string in the route
-                val recipeJson = Gson().toJson(recipe)
-                // Encode the string to prevent errors with parsing URLs
-                var encodedRecipeJson = URLEncoder.encode(recipeJson, Charsets.UTF_8.name())
-                // Encode spaces with %20 instead of + to decode the GSON properly
-                encodedRecipeJson = encodedRecipeJson.replace("+", "%20")
-
-                navController.navigate(
-                    DrawerItem.Recipe.route.replace("{recipe}", encodedRecipeJson)
-                ) {
+            Home(viewModel) {
+                navController.navigate(DrawerItem.Recipe.route) {
                     // Only have one copy of the recipe destination in the back stack
                     launchSingleTop = true
                 }
             }
         }
-        composable(DrawerItem.Recipe.route) { backStackEntry ->
-            // Parse the recipe object from the route string
-            val recipeJson = backStackEntry.arguments?.getString("recipe")
-            val recipe = Gson().fromJson(recipeJson, Recipe::class.java)
+        composable(DrawerItem.Recipe.route) {
             Recipe(viewModel)
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
@@ -48,8 +48,8 @@ fun IngredientsList(ingredients: List<Ingredient>) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier
-                    .padding(horizontal = 8.dp)
-                    .padding(bottom = 8.dp)
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 16.dp)
             ) {
                 ingredients.forEach { ingredient ->
                     Row(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.MockRecipeService
-import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.models.Ingredient
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -23,7 +23,7 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.capitalizeWords
 
 @Composable
-fun IngredientsList(recipe: Recipe) {
+fun IngredientsList(ingredients: List<Ingredient>) {
     Card(
         modifier = Modifier
             .padding(16.dp),
@@ -51,7 +51,7 @@ fun IngredientsList(recipe: Recipe) {
                     .padding(horizontal = 8.dp)
                     .padding(bottom = 8.dp)
             ) {
-                recipe.ingredients.forEach { ingredient ->
+                ingredients.forEach { ingredient ->
                     Row(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         modifier = Modifier.fillMaxWidth()
@@ -79,7 +79,7 @@ fun IngredientsList(recipe: Recipe) {
 fun IngredientsListPreview() {
     EZRecipesTheme {
         Surface {
-            IngredientsList(MockRecipeService.recipe)
+            IngredientsList(MockRecipeService.recipe.ingredients)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/InstructionsList.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/InstructionsList.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.MockRecipeService
-import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.models.Instruction
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -22,7 +22,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun InstructionsList(recipe: Recipe) {
+fun InstructionsList(instructions: List<Instruction>) {
     // Steps heading and cards
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -35,7 +35,7 @@ fun InstructionsList(recipe: Recipe) {
             modifier = Modifier.fillMaxWidth()
         )
 
-        recipe.instructions.forEach { instruction ->
+        instructions.forEach { instruction ->
             // Split each step by instruction (if applicable)
             if (instruction.name.isNotEmpty()) {
                 Text(
@@ -61,7 +61,7 @@ fun InstructionsList(recipe: Recipe) {
 fun InstructionsListPreview() {
     EZRecipesTheme {
         Surface {
-            InstructionsList(MockRecipeService.recipe)
+            InstructionsList(MockRecipeService.recipe.instructions)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/NutritionLabel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/NutritionLabel.kt
@@ -62,7 +62,9 @@ fun NutritionLabel(recipe: Recipe) {
             // Nutritional information
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.padding(horizontal = 8.dp)
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .padding(bottom = 8.dp)
             ) {
                 recipe.nutrients.forEach { nutrient ->
                     val isBold = nutrientHeadings.contains(nutrient.name)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -8,12 +8,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.MockRecipeService
-import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.RecipeRepository
+import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -21,25 +25,41 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun Recipe(recipe: Recipe) {
-    // Make the column scrollable
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(8.dp)
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        RecipeHeader(recipe = recipe)
-        NutritionLabel(recipe = recipe)
-        SummaryBox(summary = recipe.summary)
-        IngredientsList(ingredients = recipe.ingredients)
-        InstructionsList(instructions = recipe.instructions)
+fun Recipe(viewModel: MainViewModel) {
+    if (viewModel.recipe != null) {
+        val recipe = viewModel.recipe!!
 
-        Divider()
+        // Make the column scrollable
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(8.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            RecipeHeader(
+                recipe = recipe,
+                isLoading = viewModel.isLoading
+            ) {
+                // Load another recipe in the same view
+                viewModel.getRandomRecipe()
+            }
+            NutritionLabel(recipe = recipe)
+            SummaryBox(summary = recipe.summary)
+            IngredientsList(ingredients = recipe.ingredients)
+            InstructionsList(instructions = recipe.instructions)
 
-        RecipeFooter()
+            Divider()
+
+            RecipeFooter()
+        }
+    } else {
+        // Shouldn't be seen normally
+        Text(
+            text = stringResource(R.string.no_recipe),
+            modifier = Modifier.padding(8.dp)
+        )
     }
 }
 
@@ -49,9 +69,11 @@ fun Recipe(recipe: Recipe) {
 @OrientationPreviews
 @Composable
 fun RecipePreview() {
+    val viewModel = MainViewModel(RecipeRepository(MockRecipeService))
+
     EZRecipesTheme {
         Surface {
-            Recipe(MockRecipeService.recipe)
+            Recipe(viewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -70,6 +70,7 @@ fun Recipe(viewModel: MainViewModel) {
 @Composable
 fun RecipePreview() {
     val viewModel = MainViewModel(RecipeRepository(MockRecipeService))
+    viewModel.getRandomRecipe()
 
     EZRecipesTheme {
         Surface {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -33,9 +33,9 @@ fun Recipe(recipe: Recipe) {
     ) {
         RecipeHeader(recipe = recipe)
         NutritionLabel(recipe = recipe)
-        SummaryBox(recipe = recipe)
-        IngredientsList(recipe = recipe)
-        InstructionsList(recipe = recipe)
+        SummaryBox(summary = recipe.summary)
+        IngredientsList(ingredients = recipe.ingredients)
+        InstructionsList(instructions = recipe.instructions)
 
         Divider()
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
@@ -51,7 +52,6 @@ fun RecipeHeader(recipe: Recipe) {
         addStyle(
             style = SpanStyle(
                 color = Blue300,
-                fontSize = 12.sp,
                 textDecoration = TextDecoration.Underline
             ),
             start = startIndex,
@@ -88,7 +88,8 @@ fun RecipeHeader(recipe: Recipe) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             // Recipe name and source link
             Text(
@@ -98,6 +99,7 @@ fun RecipeHeader(recipe: Recipe) {
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .padding(top = 8.dp)
+                    .fillMaxWidth(0.8f)
             )
 
             IconButton(
@@ -111,7 +113,10 @@ fun RecipeHeader(recipe: Recipe) {
         AsyncImage(
             model = recipe.image,
             contentDescription = recipe.name,
-            modifier = Modifier.size(300.dp)
+            modifier = Modifier
+                .size(width = 312.dp, height = 231.dp)
+                .padding(8.dp),
+            contentScale = ContentScale.Fit
         )
 
         if (recipe.credit != null) {
@@ -134,6 +139,7 @@ fun RecipeHeader(recipe: Recipe) {
         // Recipe time and buttons
         Text(
             text = timeAnnotatedString,
+            fontSize = 20.sp,
             modifier = Modifier.padding(vertical = 8.dp)
         )
         

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -36,7 +38,7 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.capitalizeWords
 
 @Composable
-fun RecipeHeader(recipe: Recipe) {
+fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Unit) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val annotationTag = "URL"
@@ -176,7 +178,8 @@ fun RecipeHeader(recipe: Recipe) {
                     colors = ButtonDefaults.buttonColors(
                         backgroundColor = MaterialTheme.colors.secondary
                     ),
-                    onClick = { println("Showing another recipe...") }
+                    onClick = { onClickFindRecipe() },
+                    enabled = !isLoading
                 ) {
                     Icon(Icons.Default.ReceiptLong, stringResource(R.string.show_recipe_button))
                 }
@@ -186,7 +189,16 @@ fun RecipeHeader(recipe: Recipe) {
                 )
             }
         }
+
+        if (isLoading) {
+            CircularProgressIndicator()
+        }
     }
+}
+
+private class RecipeHeaderPreviewParameterProvider: PreviewParameterProvider<Boolean> {
+    // Show a preview when the view is loading and not loading
+    override val values = sequenceOf(true, false)
 }
 
 @DevicePreviews
@@ -194,10 +206,16 @@ fun RecipeHeader(recipe: Recipe) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun RecipeHeaderPreview() {
+private fun RecipeHeaderPreview(
+    @PreviewParameter(RecipeHeaderPreviewParameterProvider::class) isLoading: Boolean
+) {
     EZRecipesTheme {
         Surface {
-            RecipeHeader(MockRecipeService.recipe)
+            RecipeHeader(
+                recipe = MockRecipeService.recipe,
+                isLoading = isLoading,
+                onClickFindRecipe = {}
+            )
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
@@ -21,6 +21,8 @@ import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.google.accompanist.flowlayout.FlowRow
+import com.google.accompanist.flowlayout.SizeMode
 
 @Composable
 fun StepCard(step: Step) {
@@ -71,18 +73,26 @@ fun StepCard(step: Step) {
                         fontWeight = FontWeight.Bold
                     )
 
-                    step.ingredients.forEach { ingredient ->
-                        Column {
-                            AsyncImage(
-                                model = stringResource(R.string.ingredient_url, ingredient.image),
-                                contentDescription = ingredient.name,
-                                modifier = Modifier.size(100.dp)
-                            )
-                            Text(
-                                text = ingredient.name,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.width(100.dp)
-                            )
+                    // Wrap items if they can't fit in one row
+                    FlowRow(
+                        modifier = Modifier.padding(8.dp),
+                        mainAxisSize = SizeMode.Expand,
+                        crossAxisSpacing = 12.dp,
+                        mainAxisSpacing = 8.dp
+                    ) {
+                        step.ingredients.forEach { ingredient ->
+                            Column {
+                                AsyncImage(
+                                    model = stringResource(R.string.ingredient_url, ingredient.image),
+                                    contentDescription = ingredient.name,
+                                    modifier = Modifier.size(100.dp)
+                                )
+                                Text(
+                                    text = ingredient.name,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.width(100.dp)
+                                )
+                            }
                         }
                     }
                 }
@@ -101,18 +111,25 @@ fun StepCard(step: Step) {
                         fontWeight = FontWeight.Bold
                     )
 
-                    step.equipment.forEach { equipment ->
-                        Column {
-                            AsyncImage(
-                                model = stringResource(R.string.equipment_url, equipment.image),
-                                contentDescription = equipment.name,
-                                modifier = Modifier.size(100.dp)
-                            )
-                            Text(
-                                text = equipment.name,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.width(100.dp)
-                            )
+                    FlowRow(
+                        modifier = Modifier.padding(8.dp),
+                        mainAxisSize = SizeMode.Expand,
+                        crossAxisSpacing = 12.dp,
+                        mainAxisSpacing = 8.dp
+                    ) {
+                        step.equipment.forEach { equipment ->
+                            Column {
+                                AsyncImage(
+                                    model = stringResource(R.string.equipment_url, equipment.image),
+                                    contentDescription = equipment.name,
+                                    modifier = Modifier.size(100.dp)
+                                )
+                                Text(
+                                    text = equipment.name,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.width(100.dp)
+                                )
+                            }
                         }
                     }
                 }
@@ -129,7 +146,7 @@ fun StepCard(step: Step) {
 fun StepCardPreview() {
     EZRecipesTheme {
         Surface {
-            StepCard(MockRecipeService.recipe.instructions[0].steps[0])
+            StepCard(MockRecipeService.recipe.instructions[0].steps[3])
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
@@ -27,7 +27,7 @@ fun StepCard(step: Step) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp),
+            .padding(8.dp),
         elevation = 10.dp
     ) {
         Column(
@@ -80,7 +80,8 @@ fun StepCard(step: Step) {
                             )
                             Text(
                                 text = ingredient.name,
-                                textAlign = TextAlign.Center
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.width(100.dp)
                             )
                         }
                     }
@@ -109,7 +110,8 @@ fun StepCard(step: Step) {
                             )
                             Text(
                                 text = equipment.name,
-                                textAlign = TextAlign.Center
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier.width(100.dp)
                             )
                         }
                     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.MockRecipeService
-import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -28,7 +27,7 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.HTMLText
 
 @Composable
-fun SummaryBox(recipe: Recipe) {
+fun SummaryBox(summary: String) {
     Box(
         modifier = Modifier
             .background(MaterialTheme.colors.secondary)
@@ -61,7 +60,7 @@ fun SummaryBox(recipe: Recipe) {
             }
 
             HTMLText(
-                html = recipe.summary,
+                html = summary,
                 color = Color.Black.toArgb(),
                 fontSize = 18f
             )
@@ -77,7 +76,7 @@ fun SummaryBox(recipe: Recipe) {
 fun SummaryBoxPreview() {
     EZRecipesTheme {
         Surface {
-            SummaryBox(MockRecipeService.recipe)
+            SummaryBox(MockRecipeService.recipe.summary)
         }
     }
 }

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="ok_button">@android:string/ok</string>
 
     <!-- Recipe Screen -->
+    <string name="no_recipe">No recipe loaded</string>
     <string name="recipe_link">Open recipe source</string>
     <string name="image_copyright">Image © %1$s</string>
 

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
@@ -26,13 +26,14 @@ internal class MainViewModelTest {
         // Given an instance of MainViewModel
         // When the getRandomRecipe() method is called
         mockService.isSuccess = true
-        viewModel.getRandomRecipe()
+        val fromHome = true
+        viewModel.getRandomRecipe(fromHome)
 
         // Then the recipe property should match the mock recipe
         assertEquals(viewModel.recipe, mockService.recipe)
         assertNull(viewModel.recipeError)
         assertFalse(viewModel.isLoading)
-        assertTrue(viewModel.isRecipeLoaded)
+        assertEquals(viewModel.isRecipeLoaded, fromHome)
         assertFalse(viewModel.showRecipeAlert)
     }
 
@@ -41,7 +42,8 @@ internal class MainViewModelTest {
         // Given an instance of MainViewModel
         // When the getRandomRecipe() method is called with isSuccess = false
         mockService.isSuccess = false
-        viewModel.getRandomRecipe()
+        val fromHome = true
+        viewModel.getRandomRecipe(fromHome)
 
         // Then the recipeError property should match the mock recipeError
         assertNull(viewModel.recipe)
@@ -62,7 +64,7 @@ internal class MainViewModelTest {
         assertEquals(viewModel.recipe, mockService.recipe)
         assertNull(viewModel.recipeError)
         assertFalse(viewModel.isLoading)
-        assertTrue(viewModel.isRecipeLoaded)
+        assertFalse(viewModel.isRecipeLoaded) // fromHome is false by default
         assertFalse(viewModel.showRecipeAlert)
     }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/29958092/209899616-4f207d21-8300-4811-b1c0-ad62fdd04ffc.mp4

I polished the UI and implemented the show recipe button. To accomplish this, I moved the ViewModel to the `NavigationGraph` composable, so it could be shared between the Home and Recipe screens. Refactoring this logic wasn't too bad, but now I'm unable to preview the entire recipe page since the recipe needs to be loaded "asynchronously" (even if it's a mock). I had to alter the navigation logic to ensure the back button and hamburger menus navigated back to the home screen. (Every new recipe load replaces the recipe _contents_ on screen. It doesn't show a _new_ page. This is consistent with the iOS app but could be adjusted later as more features are added.)

Something else I learned is that there's a Screen Capture option in the Logcat, separate from the Record and Playback option in the emulator's extended controls. This makes recording videos easier since I can save them as MP4 files, which are smaller than GIFs and more universal than WEBMs. But I'm still limited to 30s recordings to fit within GitHub's 10 MB limit. (From reading the [Android docs](https://developer.android.com/studio/debug/am-video), the Logcat option is meant for real devices, but it works for the emulator as well.)

After I add the instrumentation tests, we'll be all caught up!