### PR TITLE
Android Day 11: Short Day, Short Menu

### DIFF
--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
@@ -6,8 +6,14 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.ui.navbar.NavigationDrawer
 import com.abhiek.ezrecipes.ui.navbar.NavigationGraph
@@ -17,6 +23,7 @@ import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.toPx
 
 @Composable
 fun MainLayout(
@@ -28,6 +35,7 @@ fun MainLayout(
     val scaffoldState = rememberScaffoldState(rememberDrawerState(initialDrawerState))
     // The navigation controller shouldn't be recreated in other composables
     val navController = rememberNavController()
+    val drawerWidth = 300
 
     // Material Design layout guidelines:
     // https://developer.android.com/guide/topics/large-screens/navigation-for-responsive-uis#responsive_ui_navigation
@@ -39,7 +47,17 @@ fun MainLayout(
                 TopBar(scope, scaffoldState, navController)
             },
             drawerContent = {
-                NavigationDrawer(scope, scaffoldState, navController)
+                NavigationDrawer(scope, scaffoldState, navController, drawerWidth)
+            },
+            // Limit the width of the navigation drawer so there isn't much whitespace
+            drawerShape = object : Shape {
+                override fun createOutline(
+                    size: Size,
+                    layoutDirection: LayoutDirection,
+                    density: Density
+                ) = Outline.Rectangle(
+                    Rect(left = 0f, top = 0f, right = drawerWidth.toPx, bottom = size.height)
+                )
             },
             // Content padding parameter is required: https://stackoverflow.com/a/72085218
             content = { padding ->

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
@@ -35,7 +35,9 @@ fun MainLayout(
         // Great resource for setting up the navigation drawer: https://stackoverflow.com/a/73295465
         Scaffold(
             scaffoldState = scaffoldState,
-            topBar = { TopBar(scope, scaffoldState, navController) },
+            topBar = {
+                TopBar(scope, scaffoldState, navController)
+            },
             drawerContent = {
                 NavigationDrawer(scope, scaffoldState, navController)
             },

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -29,7 +29,8 @@ import kotlinx.coroutines.launch
 fun NavigationDrawer(
     scope: CoroutineScope,
     scaffoldState: ScaffoldState,
-    navController: NavController
+    navController: NavController,
+    width: Int
 ) {
     /* Using sealedSubclasses requires reflection, which will make the app slower,
      * so list each drawer item manually
@@ -41,15 +42,18 @@ fun NavigationDrawer(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
+    // Keep the logo centered within the drawer (left padding <-> logo <-> right padding)
+    val logoWidth = 100
+    val logoHorizontalPadding = (width - logoWidth) / 2
+
     Column {
         // Show the app logo at the top
         Image(
             painter = painterResource(R.mipmap.ic_launcher_foreground),
             contentDescription = stringResource(R.string.app_logo_alt),
             modifier = Modifier
-                .height(100.dp)
-                .fillMaxWidth()
-                .padding(8.dp)
+                .height(logoWidth.dp)
+                .padding(horizontal = logoHorizontalPadding.dp, vertical = 8.dp)
         )
         Spacer(
             modifier = Modifier
@@ -90,6 +94,6 @@ fun NavigationDrawerPreview() {
     val navController = rememberNavController()
 
     EZRecipesTheme {
-        NavigationDrawer(scope, scaffoldState, navController)
+        NavigationDrawer(scope, scaffoldState, navController, 300)
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/NumberExtensions.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/NumberExtensions.kt
@@ -1,0 +1,15 @@
+package com.abhiek.ezrecipes.utils
+
+import android.content.res.Resources
+import android.util.TypedValue
+
+/**
+ * Converts a measurement in dp to px using the device's display metrics.
+ *
+ * @return the value in px
+ */
+val Number.toPx get() = TypedValue.applyDimension(
+    TypedValue.COMPLEX_UNIT_DIP,
+    this.toFloat(),
+    Resources.getSystem().displayMetrics
+)


### PR DESCRIPTION
![a smaller navigation drawer on the Nexus 10 tablet](https://user-images.githubusercontent.com/29958092/215362221-1564faeb-6193-42ce-ad5d-98353a0d89bc.png)

The only change I made today was to make the navigation drawer smaller on large screens. I applied a consistent 300 dp width to the drawer, instead of its default behavior of expanding across most of the screen's width. This reduces the amount of whitespace that would be seen on large devices. And on smaller devices, it closely resembles the default behavior anyway.

I originally planned on implementing more features to make the Android app responsive, but I figured it would be better if I save those changes for after the MVP. Once I add more screens, there would be a greater justification for creating a bottom navigation bar and a navigation rail. Yes, it might involve a lot of refactoring, but it looks better if we don't show a 1-icon navigation view than tease one for the MVP (which would make the app appear incomplete). (I know there's the hamburger menu, but I created that before I had this new plan, it was the basis for the way the composables were designed using the navigation graph, and is consistent with the web app.)

The home screen will still be a single button and I plan on adding to it past the MVP, but I didn't want to convert the layout to a sliding pane layout since I felt it would be better if both the recipe and home screens utilized their full-screen widths, aside from the leading navigation menu. (It's like that on iOS due to its default behavior, but that will be changed as well.)

The only remaining items are to explore how deep linking works across iOS and Android. And then we'll be ready to automate the deployment process on Google Play and get as far as we can outside the developer program on iOS! 😊

(P.S. I'd rather avoid doing these small PRs too frequently on Android due to the flaky nature of the emulators, but I want to make sure none of the tests are broken due to these changes.)