### PR TITLE
Switch to Ubuntu for faster pipelines

### DIFF
--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -12,6 +12,9 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
 
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/EZRecipes/Gemfile
+
     defaults:
       run:
         working-directory: "./EZRecipes"
@@ -52,6 +55,9 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [ 29, 31, 33 ]
+
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/EZRecipes/Gemfile
 
     defaults:
       run:

--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -10,7 +10,7 @@ on:
 # Split the unit and instrumentation tests into separate jobs to improve CI performance
 jobs:
   unit-test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     defaults:
       run:
@@ -19,6 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -37,7 +43,7 @@ jobs:
         run: bundle exec fastlane android test
 
   ui-test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -51,6 +57,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod u+x gradlew
 
-      - name: Install Fastlane
-        run: bundle install
+      - name: Install Ruby & Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Run unit tests
         run: bundle exec fastlane android test
@@ -74,9 +76,11 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod u+x gradlew
 
-#      - name: Install Fastlane
-#        run: bundle install
-
+#      - name: Install Ruby & Fastlane
+#        uses: ruby/setup-ruby@v1
+#        with:
+#          bundler-cache: true
+#
 #      - name: Run instrumented tests
 #        run: bundle exec fastlane android ui_test api:${{ matrix.api-level }}
       - name: Run instrumented tests

--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install Ruby & Fastlane
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '3.3'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Run unit tests
@@ -79,6 +80,7 @@ jobs:
 #      - name: Install Ruby & Fastlane
 #        uses: ruby/setup-ruby@v1
 #        with:
+#          ruby-version: '3.3'
 #          bundler-cache: true
 #
 #      - name: Run instrumented tests

--- a/EZRecipes/build.gradle
+++ b/EZRecipes/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         // Check compatibility table before updating:
         // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
         compose_ui_version = '1.6.2'
-        kotlin_compiler_version = '1.5.4'
+        kotlin_compiler_version = '1.5.10'
     }
 }
 
@@ -11,5 +11,5 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.3.0' apply false
     id 'com.android.library' version '8.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ flowchart LR
 A(Checkout repository) --> B(Enable Kernel-based Virtual Machine)
 B --> C(Install Java 17)
 C --> D(Make gradlew executable:\nchmod u+x gradlew)
-D --> E(Install Fastlane)
+D --> E(Install Ruby & Fastlane)
 E --> F(Run unit tests:\ngradlew test -p .)
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ Introducing EZ Recipes, an app that lets chefs find low-effort recipes that can 
 ```mermaid
 flowchart LR
 
-A(Checkout repository) --> B(Install Java 17)
-B --> C(Make gradlew executable:\nchmod u+x gradlew)
-C --> D(Install Fastlane)
-D --> E(Run unit tests:\ngradlew test -p .)
+A(Checkout repository) --> B(Enable Kernel-based Virtual Machine)
+B --> C(Install Java 17)
+C --> D(Make gradlew executable:\nchmod u+x gradlew)
+D --> E(Install Fastlane)
+E --> F(Run unit tests:\ngradlew test -p .)
 ```
 
 ### Instrumented Tests
@@ -51,23 +52,24 @@ D --> E(Run unit tests:\ngradlew test -p .)
 ```mermaid
 flowchart LR
 
-A(Checkout repository) --> B(Install Java 17)
-B --> C(Make gradlew executable:\nchmod u+x gradlew)
-C -->|API 29, 31, 33| D
-D --> E(Upload build reports)
+A(Checkout repository) --> B(Enable Kernel-based Virtual Machine)
+B --> C(Install Java 17)
+C --> D(Make gradlew executable:\nchmod u+x gradlew)
+D -->|API 29, 31, 33| E
+E --> F(Upload build reports)
 
-subgraph D [Run instrumented tests]
+subgraph E [Run instrumented tests]
 direction TB
-F(Accept licenses) --> G(Install build tools, platform tools, and platforms)
-G --> H(Install emulator)
-H --> I(Install system images)
-I --> J(Create test AVD)
-J --> K(Configure AVD with 2 cores)
-K --> L(Boot up the emulator)
-L --> M(Press the menu button)
-M --> N(Disable animations)
-N --> O(Run instrumented tests:\ngradlew connectedAndroidTest)
-O --> P(Kill emulator)
+G(Accept licenses) --> H(Install build tools, platform tools, and platforms)
+H --> I(Install emulator)
+I --> J(Install system images)
+J --> K(Create test AVD)
+K --> L(Configure AVD with 2 cores)
+L --> M(Boot up the emulator)
+M --> N(Press the menu button)
+N --> O(Disable animations)
+O --> P(Run instrumented tests:\ngradlew connectedAndroidTest)
+P --> Q(Kill emulator)
 end
 ```
 


### PR DESCRIPTION
Copying the changes from https://github.com/Abhiek187/calculators/pull/128 because the performance bump is so good!

Let's compare the performance from my benchmarks here: https://github.com/Abhiek187/ez-recipes-android/pull/10#issuecomment-1304997300 (API 33)

| Step | Ubuntu | macOS |
| :-: | :-: | :-: |
| Change owner | 6s | 0s |
| Accept licenses | 3s | 6s |
| Install build/platform tools | 2s | 2s |
| Install emulator | 7s | 16s |
| Install system images | 2m 6s | 41s |
| Create AVD | 1s | 2s |
| Configure 2 cores | 0s | 0s |
| Start emulator | 10s | 10s |
| Wait to boot | 24s | 5m 59s |
| Disable animations | 1s | 1s |
| Run tests | 2m 17s | 7m 40s |
| Kill emulator | 0s | 0s |
| Total | 5m 22s | 15m 2s |

Booting up the emulator is 15x faster and running all the tests is 3x faster on Ubuntu than on macOS.