### PR TITLE
Feature/recipe details 2

### DIFF
--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/adapters/CuisineTypeAdapter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/adapters/CuisineTypeAdapter.kt
@@ -1,0 +1,25 @@
+package com.abhiek.ezrecipes.data.adapters
+
+import android.util.Log
+import com.abhiek.ezrecipes.data.models.Cuisine
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.lang.IllegalArgumentException
+
+class CuisineTypeAdapter: TypeAdapter<Cuisine>() {
+    override fun write(writer: JsonWriter?, value: Cuisine?) {
+        writer?.value(value?.toString())
+    }
+
+    override fun read(reader: JsonReader?): Cuisine {
+        val stringValue = reader?.nextString()?.replace(" ", "_")?.uppercase()
+
+        return try {
+            Cuisine.valueOf(stringValue ?: "")
+        } catch (error: IllegalArgumentException) {
+            Log.w(CuisineTypeAdapter::class.simpleName, "Encountered an unknown cuisine: $stringValue")
+            Cuisine.UNKNOWN
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/adapters/MealTypeAdapter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/adapters/MealTypeAdapter.kt
@@ -1,0 +1,30 @@
+package com.abhiek.ezrecipes.data.adapters
+
+import android.util.Log
+import com.abhiek.ezrecipes.data.models.MealType
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.lang.IllegalArgumentException
+
+class MealTypeAdapter: TypeAdapter<MealType>() {
+    override fun write(writer: JsonWriter?, value: MealType?) {
+        writer?.value(value?.toString())
+    }
+
+    override fun read(reader: JsonReader?): MealType {
+        val rawStringValue = reader?.nextString()
+        val stringValue = if (rawStringValue == "hor d'oeuvre") {
+            "HOR_D_OEUVRE"
+        } else {
+            rawStringValue?.replace(" ", "_")?.uppercase()
+        }
+
+        return try {
+            MealType.valueOf(stringValue ?: "")
+        } catch (error: IllegalArgumentException) {
+            Log.w(MealTypeAdapter::class.simpleName, "Encountered an unknown meal type: $stringValue")
+            MealType.UNKNOWN
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/adapters/SpiceLevelTypeAdapter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/adapters/SpiceLevelTypeAdapter.kt
@@ -1,0 +1,28 @@
+package com.abhiek.ezrecipes.data.adapters
+
+import android.util.Log
+import com.abhiek.ezrecipes.data.models.SpiceLevel
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.lang.IllegalArgumentException
+
+class SpiceLevelTypeAdapter: TypeAdapter<SpiceLevel>() {
+    override fun write(writer: JsonWriter?, value: SpiceLevel?) {
+        // Encode spice levels using the same toString() method
+        writer?.value(value?.toString())
+    }
+
+    override fun read(reader: JsonReader?): SpiceLevel {
+        // Reverse the logic of toString() and determine if the value matches any enum value
+        val stringValue = reader?.nextString()?.uppercase()
+
+        return try {
+            SpiceLevel.valueOf(stringValue ?: "")
+        } catch (error: IllegalArgumentException) {
+            // Default to unknown if spoonacular returns a value that's undocumented
+            Log.w(SpiceLevelTypeAdapter::class.simpleName, "Encountered an unknown spice level: $stringValue")
+            SpiceLevel.UNKNOWN
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Cuisine.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Cuisine.kt
@@ -1,5 +1,7 @@
 package com.abhiek.ezrecipes.data.models
 
+import com.abhiek.ezrecipes.utils.capitalizeWords
+
 enum class Cuisine {
     AFRICAN,
     ASIAN,
@@ -30,5 +32,7 @@ enum class Cuisine {
     VIETNAMESE,
     ENGLISH,
     SCOTTISH,
-    UNKNOWN
+    UNKNOWN;
+
+    override fun toString() = name.replace("_", " ").lowercase().capitalizeWords()
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/MealType.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/MealType.kt
@@ -27,5 +27,11 @@ enum class MealType {
     CONDIMENT,
     DIP,
     SPREAD,
-    UNKNOWN
+    UNKNOWN;
+
+    override fun toString(): String {
+        if (name == "HOR_D_OEUVRE") return "hor d'oeuvre"
+
+        return name.replace("_", " ").lowercase()
+    }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/SpiceLevel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/SpiceLevel.kt
@@ -1,5 +1,7 @@
 package com.abhiek.ezrecipes.data.models
 
 enum class SpiceLevel {
-    NONE, MILD, SPICY, UNKNOWN
+    NONE, MILD, SPICY, UNKNOWN;
+
+    override fun toString() = name.lowercase()
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeService.kt
@@ -1,8 +1,11 @@
 package com.abhiek.ezrecipes.data.recipe
 
-import com.abhiek.ezrecipes.data.models.Recipe
-import com.abhiek.ezrecipes.data.models.RecipeFilter
+import com.abhiek.ezrecipes.data.adapters.CuisineTypeAdapter
+import com.abhiek.ezrecipes.data.adapters.MealTypeAdapter
+import com.abhiek.ezrecipes.data.adapters.SpiceLevelTypeAdapter
+import com.abhiek.ezrecipes.data.models.*
 import com.abhiek.ezrecipes.utils.Constants
+import com.google.gson.GsonBuilder
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Response
@@ -48,9 +51,14 @@ interface RecipeService {
                     .build()
 
                 // Convert responses to GSON (Google JSON)
+                val gsonBuilder = GsonBuilder()
+                    .registerTypeAdapter(Cuisine::class.java, CuisineTypeAdapter())
+                    .registerTypeAdapter(MealType::class.java, MealTypeAdapter())
+                    .registerTypeAdapter(SpiceLevel::class.java, SpiceLevelTypeAdapter())
+                    .create()
                 val retrofit = Retrofit.Builder()
                     .baseUrl(Constants.SERVER_BASE_URL + Constants.RECIPE_PATH)
-                    .addConverterFactory(GsonConverterFactory.create())
+                    .addConverterFactory(GsonConverterFactory.create(gsonBuilder))
                     .client(httpClient)
                     .build()
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -85,7 +85,9 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        // Allow content to take up the full width if needed
+        modifier = Modifier.width(IntrinsicSize.Max)
     ) {
         // Recipe image and caption
         AsyncImage(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -11,8 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -53,6 +53,7 @@ private fun boldAnnotatedString(
 
 @Composable
 fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Unit) {
+    val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val annotationTag = "URL"
 
@@ -127,7 +128,8 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
         // Recipe time and buttons
         Text(
             text = boldAnnotatedString(
-                text = pluralStringResource(id = R.plurals.recipe_time, count = recipe.time),
+                // 2nd arg = count, 3rd arg = formatter args
+                text = context.resources.getQuantityString(R.plurals.recipe_time, recipe.time, recipe.time),
                 endIndex = 5 // "Time:".length = 5
             ),
             style = MaterialTheme.typography.h6,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -11,8 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -34,9 +34,25 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.Blue300
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
+private fun boldAnnotatedString(
+    text: String,
+    startIndex: Int = 0,
+    endIndex: Int
+) = buildAnnotatedString {
+    append(text)
+
+    // Bold only the portion: [startIndex, endIndex)
+    addStyle(
+        style = SpanStyle(
+            fontWeight = FontWeight.Bold
+        ),
+        start = startIndex,
+        end = endIndex
+    )
+}
+
 @Composable
 fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Unit) {
-    val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val annotationTag = "URL"
 
@@ -61,22 +77,6 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
         addStringAnnotation(
             tag = annotationTag,
             annotation = recipe.sourceUrl,
-            start = startIndex,
-            end = endIndex
-        )
-    }
-
-    val timeAnnotatedString = buildAnnotatedString {
-        val str = context.resources.getQuantityString(R.plurals.recipe_time, recipe.time, recipe.time)
-        val startIndex = 0
-        val endIndex = 5 // "Time:".length = 5
-        append(str)
-
-        // Bold only the time portion of the string
-        addStyle(
-            style = SpanStyle(
-                fontWeight = FontWeight.Bold
-            ),
             start = startIndex,
             end = endIndex
         )
@@ -113,15 +113,59 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
             }
         }
 
+        // Recipe info
+        RecipePills(
+            spiceLevel = recipe.spiceLevel,
+            isVegetarian = recipe.isVegetarian,
+            isVegan = recipe.isVegan,
+            isGlutenFree = recipe.isGlutenFree,
+            isHealthy = recipe.isHealthy,
+            isCheap = recipe.isCheap,
+            isSustainable = recipe.isSustainable
+        )
+
         // Recipe time and buttons
         Text(
-            text = timeAnnotatedString,
+            text = boldAnnotatedString(
+                text = pluralStringResource(id = R.plurals.recipe_time, count = recipe.time),
+                endIndex = 5 // "Time:".length = 5
+            ),
             style = MaterialTheme.typography.h6,
             modifier = Modifier.padding(vertical = 8.dp)
         )
+
+        if (recipe.types.isNotEmpty()) {
+            Text(
+                text = boldAnnotatedString(
+                    text = stringResource(
+                        R.string.recipe_meal_types,
+                        recipe.types.joinToString(", ")
+                    ),
+                    endIndex = 10 // "Great for:".length = 10
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+        }
+        if (recipe.culture.isNotEmpty()) {
+            Text(
+                text = boldAnnotatedString(
+                    text = stringResource(
+                        R.string.recipe_cuisines,
+                        recipe.culture.joinToString(", ")
+                    ),
+                    endIndex = 9 // "Cuisines:".length = 9
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+        }
         
         Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(top = 8.dp)
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -196,7 +240,7 @@ private fun RecipeHeaderPreview(
     EZRecipesTheme {
         Surface {
             RecipeHeader(
-                recipe = MockRecipeService.recipes[1],
+                recipe = MockRecipeService.recipes[2],
                 isLoading = isLoading,
                 onClickFindRecipe = {}
             )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipePills.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipePills.kt
@@ -1,0 +1,157 @@
+package com.abhiek.ezrecipes.ui.recipe
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.models.SpiceLevel
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.Amber700
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.capitalizeWords
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun RecipePills(
+    spiceLevel: SpiceLevel,
+    isVegetarian: Boolean,
+    isVegan: Boolean,
+    isGlutenFree: Boolean,
+    isHealthy: Boolean,
+    isCheap: Boolean,
+    isSustainable: Boolean
+) {
+    FlowRow(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        if (spiceLevel == SpiceLevel.MILD || spiceLevel == SpiceLevel.SPICY) {
+            Pill(
+                text = spiceLevel.toString().capitalizeWords(),
+                backgroundColor = if (spiceLevel == SpiceLevel.MILD) Amber700 else Color.Red
+            )
+        }
+        if (isVegetarian) {
+            Pill(
+                text = stringResource(R.string.vegetarian_label),
+                backgroundColor = MaterialTheme.colors.primary
+            )
+        }
+        if (isVegan) {
+            Pill(
+                text = stringResource(R.string.vegan_label),
+                backgroundColor = MaterialTheme.colors.primary
+            )
+        }
+        if (isGlutenFree) {
+            Pill(
+                text = stringResource(R.string.gluten_free_label),
+                backgroundColor = MaterialTheme.colors.primary
+            )
+        }
+        if (isHealthy) {
+            Pill(
+                text = stringResource(R.string.healthy_label),
+                backgroundColor = MaterialTheme.colors.primary
+            )
+        }
+        if (isCheap) {
+            Pill(
+                text = stringResource(R.string.cheap_label),
+                backgroundColor = MaterialTheme.colors.primary
+            )
+        }
+        if (isSustainable) {
+            Pill(
+                text = stringResource(R.string.sustainable_label),
+                backgroundColor = MaterialTheme.colors.primary
+            )
+        }
+    }
+}
+
+@Composable
+private fun Pill(text: String, backgroundColor: Color, textColor: Color = Color.Black) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = backgroundColor,
+                shape = RoundedCornerShape(corner = CornerSize(50)))
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = text,
+            color = textColor,
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}
+
+private data class RecipePillsState(
+    val spiceLevel: SpiceLevel = SpiceLevel.NONE,
+    val isVegetarian: Boolean = false,
+    val isVegan: Boolean = false,
+    val isGlutenFree: Boolean = false,
+    val isHealthy: Boolean = false,
+    val isCheap: Boolean = false,
+    val isSustainable: Boolean = false
+)
+
+private class RecipePillsPreviewParameterProvider: PreviewParameterProvider<RecipePillsState> {
+    override val values = sequenceOf(
+        RecipePillsState(isVegetarian = true, isVegan = true),
+        RecipePillsState(spiceLevel = SpiceLevel.MILD, isGlutenFree = true, isHealthy = true),
+        RecipePillsState(
+            spiceLevel = SpiceLevel.SPICY,
+            isVegetarian = true,
+            isVegan = true,
+            isGlutenFree = true,
+            isHealthy = true,
+            isCheap = true,
+            isSustainable = true
+        )
+    )
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun RecipePillsPreview(
+    @PreviewParameter(RecipePillsPreviewParameterProvider::class) state: RecipePillsState
+) {
+    EZRecipesTheme {
+        Surface {
+            RecipePills(
+                state.spiceLevel,
+                state.isVegetarian,
+                state.isVegan,
+                state.isGlutenFree,
+                state.isHealthy,
+                state.isCheap,
+                state.isSustainable
+            )
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipePills.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipePills.kt
@@ -37,9 +37,7 @@ fun RecipePills(
     isSustainable: Boolean
 ) {
     FlowRow(
-        modifier = Modifier
-            .padding(8.dp)
-            .fillMaxWidth(),
+        modifier = Modifier.padding(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/models/CuisineTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/models/CuisineTest.kt
@@ -1,0 +1,17 @@
+package com.abhiek.ezrecipes.data.models
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class CuisineTest {
+    @Test
+    fun testToString() {
+        assertEquals("African", Cuisine.AFRICAN.toString())
+        assertEquals("Mediterranean", Cuisine.MEDITERRANEAN.toString())
+        assertEquals("Unknown", Cuisine.UNKNOWN.toString())
+
+        assertEquals("Eastern European", Cuisine.EASTERN_EUROPEAN.toString())
+        assertEquals("Latin American", Cuisine.LATIN_AMERICAN.toString())
+        assertEquals("Middle Eastern", Cuisine.MIDDLE_EASTERN.toString())
+    }
+}

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/models/MealTypeTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/models/MealTypeTest.kt
@@ -1,0 +1,19 @@
+package com.abhiek.ezrecipes.data.models
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class MealTypeTest {
+    @Test
+    fun testToString() {
+        assertEquals("fingerfood", MealType.FINGERFOOD.toString())
+        assertEquals("antipasti", MealType.ANTIPASTI.toString())
+        assertEquals("unknown", MealType.UNKNOWN.toString())
+
+        assertEquals("main course", MealType.MAIN_COURSE.toString())
+        assertEquals("main dish", MealType.MAIN_DISH.toString())
+        assertEquals("morning meal", MealType.MORNING_MEAL.toString())
+
+        assertEquals("hor d'oeuvre", MealType.HOR_D_OEUVRE.toString())
+    }
+}

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/models/SpiceLevelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/models/SpiceLevelTest.kt
@@ -1,0 +1,14 @@
+package com.abhiek.ezrecipes.data.models
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class SpiceLevelTest {
+    @Test
+    fun testToString() {
+        assertEquals("none", SpiceLevel.NONE.toString())
+        assertEquals("mild", SpiceLevel.MILD.toString())
+        assertEquals("spicy", SpiceLevel.SPICY.toString())
+        assertEquals("unknown", SpiceLevel.UNKNOWN.toString())
+    }
+}


### PR DESCRIPTION
| Screen Type | Light Mode | Dark Mode |
| - | - | - |
| Phone | ![image](https://github.com/Abhiek187/ez-recipes-android/assets/29958092/f7498811-0db9-4bcb-9ef4-8ca4d06d90b2) | ![image](https://github.com/Abhiek187/ez-recipes-android/assets/29958092/c1dbf529-1be2-4169-969b-013afba51758) |
| Tablet | ![image](https://github.com/Abhiek187/ez-recipes-android/assets/29958092/f868d335-b489-44f1-92e4-e043eefe77c3) | ![image](https://github.com/Abhiek187/ez-recipes-android/assets/29958092/8a3ddce5-9e8a-49a1-9629-e9ad8bed454e) |

The Android implementation of https://github.com/Abhiek187/ez-recipes-web/issues/208.

The trickiest part was trying to figure out how to parse the JSON responses into enums. With help from ChatGPT, I created custom TypeAdapters for the spice level, cuisine, and meal types. Like with iOS, I add a warning log if an unknown value is received by the API.