### PR TITLE
Responsive Search

### DIFF
--- a/EZRecipes/app/proguard-rules.pro
+++ b/EZRecipes/app/proguard-rules.pro
@@ -42,3 +42,8 @@
 # kept. Suspend functions are wrapped in continuations where the type argument
 # is used.
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# Fixes "Missing type parameter": https://stackoverflow.com/a/72520577
+-keep class com.google.gson.reflect.TypeToken
+-keep class * extends com.google.gson.reflect.TypeToken
+-keep public class * implements java.lang.reflect.Type

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
@@ -250,14 +250,38 @@ internal class EZRecipesInstrumentedTest {
     @Test
     fun testSearchRecipes() {
         // Click the search tab
+        // Use the hamburger menu on large screens
+        val hamburgerMenu = composeTestRule
+            .onNodeWithContentDescription(activity.getString(R.string.hamburger_menu_alt))
+
+        if (hamburgerMenu.isDisplayed()) {
+            hamburgerMenu
+                .assertHasClickAction()
+                .performClick()
+            composeTestRule
+                .onNodeWithContentDescription(activity.getString(R.string.app_logo_alt))
+                .assertExists()
+        }
+
         val searchTab = composeTestRule
             .onNodeWithText(activity.getString(R.string.search_tab))
         searchTab.performClick()
+
+        // Interact with all the filter options
+        // The results placeholder should only show on large screens
+        val resultsTitle = composeTestRule
+            .onNodeWithText(activity.getString(R.string.results_title))
+        val resultsPlaceholder = composeTestRule
+            .onNodeWithText(activity.getString(R.string.results_placeholder))
+
+        if (resultsPlaceholder.isDisplayed()) {
+            resultsTitle.assertExists()
+            resultsPlaceholder.assertExists()
+        }
+
         var shotNum = 1
         screenshot("search-screen", shotNum)
         shotNum += 1
-
-        // Interact with all the filter options
         composeTestRule
             .onNodeWithText(activity.getString(R.string.query_section))
             .performTextInput("pasta")
@@ -369,11 +393,17 @@ internal class EZRecipesInstrumentedTest {
 
         // Submit the form and wait for results
         submitButton.performClick()
-        composeTestRule.waitUntil(timeoutMillis = 30_000) {
-            composeTestRule
-                .onAllNodesWithText(activity.getString(R.string.results_title))
-                .fetchSemanticsNodes()
-                .isNotEmpty()
+
+        if (resultsPlaceholder.isDisplayed()) {
+            // Wait until the placeholder disappears on large screens
+            composeTestRule.waitUntil(timeoutMillis = 30_000) {
+                resultsPlaceholder.isNotDisplayed()
+            }
+        } else {
+            // Wait until the results are shown on small screens
+            composeTestRule.waitUntil(timeoutMillis = 30_000) {
+                resultsTitle.isDisplayed()
+            }
         }
         screenshot("search-screen", shotNum)
         shotNum += 1

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
@@ -114,6 +114,7 @@ internal class EZRecipesInstrumentedTest {
         // Wait up to 30 seconds for the recipe to load
         // waitUntil defaults to 1 second before timeout
         composeTestRule.waitUntil(timeoutMillis = 30_000) {
+            // Expression must be a boolean
             composeTestRule
                 .onAllNodesWithText(activity.getString(R.string.find_recipe_button))
                 .fetchSemanticsNodes()
@@ -249,9 +250,9 @@ internal class EZRecipesInstrumentedTest {
     @Test
     fun testSearchRecipes() {
         // Click the search tab
-        composeTestRule
+        val searchTab = composeTestRule
             .onNodeWithText(activity.getString(R.string.search_tab))
-            .performClick()
+        searchTab.performClick()
         var shotNum = 1
         screenshot("search-screen", shotNum)
         shotNum += 1
@@ -294,5 +295,87 @@ internal class EZRecipesInstrumentedTest {
         calorieRangeError.assertDoesNotExist()
         maxCaloriesError.assertDoesNotExist()
         submitButton.assertIsEnabled()
+
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.vegetarian_label))
+            .assertExists()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.vegan_label))
+            .assertExists()
+            .performClick()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.gluten_free_label))
+            .assertExists()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.healthy_label))
+            .assertExists()
+            .performClick()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.cheap_label))
+            .assertExists()
+            .performClick()
+            .performClick()
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.sustainable_label))
+            .assertExists()
+            .performClick()
+            .performClick()
+
+        val spiceLevelDropdown = composeTestRule
+            .onNodeWithText(activity.getString(R.string.spice_label))
+        spiceLevelDropdown.performClick()
+        composeTestRule
+            .onNodeWithText("none")
+            .performClick()
+        composeTestRule
+            .onNodeWithText("mild")
+            .performClick()
+        composeTestRule
+            .onNodeWithText("spicy")
+            .performClick()
+            .performClick()
+        spiceLevelDropdown.performClick()
+
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.type_label))
+            .performClick()
+        composeTestRule
+            .onNodeWithText("dinner")
+            .performClick()
+        composeTestRule
+            .onNodeWithText("lunch")
+            .performClick()
+        composeTestRule
+            .onNodeWithText("main course")
+            .performClick()
+        composeTestRule
+            .onNodeWithText("main dish")
+            .performClick()
+        searchTab.performClick()
+
+        composeTestRule
+            .onNodeWithText(activity.getString(R.string.culture_label))
+            .performClick()
+        composeTestRule
+            .onNodeWithText("Italian")
+            .performClick()
+        searchTab.performClick()
+        screenshot("search-screen", shotNum)
+        shotNum += 1
+
+        // Submit the form and wait for results
+        submitButton.performClick()
+        composeTestRule.waitUntil(timeoutMillis = 30_000) {
+            composeTestRule
+                .onAllNodesWithText(activity.getString(R.string.results_title))
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        screenshot("search-screen", shotNum)
+        shotNum += 1
     }
 }

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
@@ -253,6 +253,7 @@ internal class EZRecipesInstrumentedTest {
         // Use the hamburger menu on large screens
         val hamburgerMenu = composeTestRule
             .onNodeWithContentDescription(activity.getString(R.string.hamburger_menu_alt))
+        var shotNum = 1
 
         if (hamburgerMenu.isDisplayed()) {
             hamburgerMenu
@@ -261,6 +262,8 @@ internal class EZRecipesInstrumentedTest {
             composeTestRule
                 .onNodeWithContentDescription(activity.getString(R.string.app_logo_alt))
                 .assertExists()
+            screenshot("search-screen", shotNum)
+            shotNum += 1
         }
 
         val searchTab = composeTestRule
@@ -279,7 +282,6 @@ internal class EZRecipesInstrumentedTest {
             resultsPlaceholder.assertExists()
         }
 
-        var shotNum = 1
         screenshot("search-screen", shotNum)
         shotNum += 1
         composeTestRule

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
@@ -353,7 +353,9 @@ internal class EZRecipesInstrumentedTest {
 
         val spiceLevelDropdown = composeTestRule
             .onNodeWithText(activity.getString(R.string.spice_label))
-        spiceLevelDropdown.performClick()
+        spiceLevelDropdown
+            .performScrollTo()
+            .performClick()
         composeTestRule
             .onNodeWithText("none")
             .performClick()
@@ -366,35 +368,45 @@ internal class EZRecipesInstrumentedTest {
             .performClick()
         spiceLevelDropdown.performClick()
 
-        composeTestRule
+        val mealTypeDropdown = composeTestRule
             .onNodeWithText(activity.getString(R.string.type_label))
+        mealTypeDropdown
+            .performScrollTo()
             .performClick()
         composeTestRule
             .onNodeWithText("dinner")
             .performClick()
         composeTestRule
             .onNodeWithText("lunch")
+            .performScrollTo()
             .performClick()
         composeTestRule
             .onNodeWithText("main course")
+            .performScrollTo()
             .performClick()
         composeTestRule
             .onNodeWithText("main dish")
+            .performScrollTo()
             .performClick()
-        searchTab.performClick()
+        mealTypeDropdown.performClick()
 
-        composeTestRule
+        val cuisineDropdown = composeTestRule
             .onNodeWithText(activity.getString(R.string.culture_label))
+        cuisineDropdown
+            .performScrollTo()
             .performClick()
         composeTestRule
             .onNodeWithText("Italian")
+            .performScrollTo()
             .performClick()
-        searchTab.performClick()
+        cuisineDropdown.performClick()
         screenshot("search-screen", shotNum)
         shotNum += 1
 
         // Submit the form and wait for results
-        submitButton.performClick()
+        submitButton
+            .performScrollTo()
+            .performClick()
 
         if (resultsPlaceholder.isDisplayed()) {
             // Wait until the placeholder disappears on large screens

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
@@ -50,7 +50,8 @@ fun DrawerListItem(item: Tab, selected: Boolean, onItemClick: () -> Unit) {
             style = MaterialTheme.typography.subtitle1.copy(
                 fontSize = 18.sp
             ),
-            color = if (selected) Color.Black else MaterialTheme.colors.onBackground
+            color = if (selected) Color.Black else MaterialTheme.colors.onBackground,
+            modifier = Modifier.clickable(onClick = onItemClick)
         )
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavRail.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavRail.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
@@ -28,11 +29,11 @@ fun NavRail(navController: NavController) {
                 selected = currentRoute == item.route,
                 onClick = {
                     navController.navigate(item.route) {
-                        // Pop all previous routes from the back stack until the selected route is found
-                        navController.graph.startDestinationRoute?.let { route ->
-                            popUpTo(route)
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
                         }
                         launchSingleTop = true
+                        restoreState = true
                     }
                 }
             )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.R
@@ -66,11 +67,11 @@ fun NavigationDrawer(
                 selected = currentRoute == item.route,
                 onItemClick = {
                     navController.navigate(item.route) {
-                        // Pop all previous routes from the back stack until the selected route is found
-                        navController.graph.startDestinationRoute?.let { route ->
-                            popUpTo(route)
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
                         }
                         launchSingleTop = true
+                        restoreState = true
                     }
                     scope.launch {
                         scaffoldState.drawerState.close()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -2,10 +2,7 @@ package com.abhiek.ezrecipes.ui.navbar
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.DrawerValue
-import androidx.compose.material.ScaffoldState
-import androidx.compose.material.rememberDrawerState
-import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -87,12 +84,14 @@ fun NavigationDrawer(
 @FontPreviews
 @OrientationPreviews
 @Composable
-fun NavigationDrawerPreview() {
+private fun NavigationDrawerPreview() {
     val scope = rememberCoroutineScope()
     val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
     val navController = rememberNavController()
 
     EZRecipesTheme {
-        NavigationDrawer(scope, scaffoldState, navController, 300)
+        Surface {
+            NavigationDrawer(scope, scaffoldState, navController, 300)
+        }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -119,7 +119,9 @@ fun NavigationGraph(
                             Constants.Routes.RECIPE.replace(
                                 "{id}", mainViewModel.recipe?.id.toString()
                             )
-                        )
+                        ) {
+                            launchSingleTop = true
+                        }
                     }
                 }
             }
@@ -137,7 +139,9 @@ fun NavigationGraph(
                         Constants.Routes.RECIPE.replace(
                             "{id}", mainViewModel.recipe?.id.toString()
                         )
-                    )
+                    ) {
+                        launchSingleTop = true
+                    }
                 }
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -1,24 +1,41 @@
 package com.abhiek.ezrecipes.ui.navbar
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.Surface
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navDeepLink
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.MainViewModelFactory
 import com.abhiek.ezrecipes.ui.home.Home
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.recipe.Recipe
 import com.abhiek.ezrecipes.ui.search.FilterForm
 import com.abhiek.ezrecipes.ui.search.SearchResults
 import com.abhiek.ezrecipes.ui.search.SearchViewModel
 import com.abhiek.ezrecipes.ui.search.SearchViewModelFactory
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.*
 
 @Composable
-fun NavigationGraph(navController: NavHostController, widthSizeClass: WindowWidthSizeClass) {
+fun NavigationGraph(
+    navController: NavHostController,
+    widthSizeClass: WindowWidthSizeClass,
+    startDestination: String = Constants.Routes.HOME
+) {
     val mainViewModel = viewModel<MainViewModel>(
         factory = MainViewModelFactory()
     )
@@ -31,7 +48,7 @@ fun NavigationGraph(navController: NavHostController, widthSizeClass: WindowWidt
     // NavHostController is a subclass of NavController
     NavHost(
         navController = navController,
-        startDestination = Constants.Routes.HOME
+        startDestination = startDestination
     ) {
         composable(
             Constants.Routes.HOME,
@@ -78,8 +95,33 @@ fun NavigationGraph(navController: NavHostController, widthSizeClass: WindowWidt
                 { slideRightEnter() }
             } else null
         ) {
-            FilterForm(searchViewModel) {
-                navController.navigate(Constants.Routes.RESULTS)
+            // On large screens, show the form and results side-by-side
+            if (widthSizeClass == WindowWidthSizeClass.Compact) {
+                FilterForm(searchViewModel) {
+                    navController.navigate(Constants.Routes.RESULTS)
+                }
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    FilterForm(
+                        searchViewModel,
+                        modifier = Modifier.weight(1f)
+                    ) {}
+                    SearchResults(
+                        searchViewModel.recipes,
+                        mainViewModel,
+                        modifier = Modifier.weight(
+                            if (widthSizeClass == WindowWidthSizeClass.Medium) 1f else 2f
+                        )
+                    ) {
+                        navController.navigate(
+                            Constants.Routes.RECIPE.replace(
+                                "{id}", mainViewModel.recipe?.id.toString()
+                            )
+                        )
+                    }
+                }
             }
         }
         composable(
@@ -89,13 +131,42 @@ fun NavigationGraph(navController: NavHostController, widthSizeClass: WindowWidt
             popEnterTransition = { slideRightEnter() },
             popExitTransition = { slideRightExit() }
         ) {
-            SearchResults(searchViewModel.recipes, mainViewModel) {
-                navController.navigate(
-                    Constants.Routes.RECIPE.replace(
-                        "{id}", mainViewModel.recipe?.id.toString()
+            Row {
+                SearchResults(searchViewModel.recipes, mainViewModel) {
+                    navController.navigate(
+                        Constants.Routes.RECIPE.replace(
+                            "{id}", mainViewModel.recipe?.id.toString()
+                        )
                     )
-                )
+                }
             }
+        }
+    }
+}
+
+private class NavigationGraphPreviewParameterProvider: PreviewParameterProvider<String> {
+    override val values = sequenceOf(
+        Constants.Routes.HOME,
+        Constants.Routes.RECIPE,
+        Constants.Routes.SEARCH,
+        Constants.Routes.RESULTS
+    )
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun NavigationGraphPreview(
+    @PreviewParameter(NavigationGraphPreviewParameterProvider::class) route: String
+) {
+    val navController = rememberNavController()
+    val windowSize = currentWindowSize()
+
+    EZRecipesTheme {
+        Surface {
+            NavigationGraph(navController, windowSize.widthSizeClass, route)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/FilterForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/FilterForm.kt
@@ -38,7 +38,11 @@ import com.abhiek.ezrecipes.utils.getActivity
 import kotlin.math.floor
 
 @Composable
-fun FilterForm(searchViewModel: SearchViewModel, onNavigateToResults: () -> Unit) {
+fun FilterForm(
+    searchViewModel: SearchViewModel,
+    modifier: Modifier = Modifier,
+    onNavigateToResults: () -> Unit
+) {
     var caloriesExceedMax by remember { mutableStateOf(false) }
     var caloriesInvalidRange by remember { mutableStateOf(false) }
 
@@ -72,9 +76,9 @@ fun FilterForm(searchViewModel: SearchViewModel, onNavigateToResults: () -> Unit
 
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
             .padding(16.dp)
+            .fillMaxHeight()
             .verticalScroll(rememberScrollState())
     ) {
         TextField(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/FilterForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/FilterForm.kt
@@ -103,6 +103,16 @@ fun FilterForm(
                 TextField(
                     value = searchViewModel.recipeFilter.minCals?.toString() ?: "",
                     onValueChange = {
+                        if (it.isEmpty()) {
+                            // Treat empty inputs as null
+                            searchViewModel.recipeFilter =
+                                searchViewModel.recipeFilter.copy(minCals = null)
+                            caloriesExceedMax = (searchViewModel.recipeFilter.maxCals
+                                ?: Constants.MIN_CALS) > Constants.MAX_CALS
+                            caloriesInvalidRange = false
+                            return@TextField
+                        }
+
                         // Disregard decimals (to be more consistent with other platforms)
                         val parsedValue = it.toFloatOrNull() ?: return@TextField
                         val newValue = floor(parsedValue).toInt()
@@ -127,6 +137,15 @@ fun FilterForm(
                 TextField(
                     value = searchViewModel.recipeFilter.maxCals?.toString() ?: "",
                     onValueChange = {
+                        if (it.isEmpty()) {
+                            searchViewModel.recipeFilter =
+                                searchViewModel.recipeFilter.copy(maxCals = null)
+                            caloriesExceedMax = (searchViewModel.recipeFilter.minCals
+                                ?: Constants.MIN_CALS) > Constants.MAX_CALS
+                            caloriesInvalidRange = false
+                            return@TextField
+                        }
+
                         val parsedValue = it.toFloatOrNull() ?: return@TextField
                         val newValue = floor(parsedValue).toInt()
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
@@ -55,7 +55,7 @@ fun <T> MultiSelectDropdown(
                 disabledTrailingIconColor = MaterialTheme.colors.onSurface
             ),
             modifier = Modifier
-                .clickable { expanded = true }
+                .clickable { expanded = !expanded }
                 .onGloballyPositioned { coordinates ->
                     textFieldSize = coordinates.size.toSize()
                 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
@@ -34,7 +34,6 @@ fun RecipeCard(recipe: Recipe, onClick: () -> Unit) {
 
     Card(
         modifier = Modifier
-            .widthIn(min = 350.dp, max = 450.dp)
             .padding(8.dp)
             .clickable { onClick() },
         elevation = 2.dp
@@ -65,10 +64,10 @@ fun RecipeCard(recipe: Recipe, onClick: () -> Unit) {
                 )
                 IconButton(onClick = { isFavorite = !isFavorite }) {
                     Icon(
-                        imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
-                        contentDescription = if (isFavorite) stringResource(R.string.un_favorite_alt) else stringResource(
-                            R.string.favorite_alt
-                        ),
+                        imageVector = if (isFavorite) Icons.Filled.Favorite
+                            else Icons.Filled.FavoriteBorder,
+                        contentDescription = if (isFavorite) stringResource(R.string.un_favorite_alt)
+                            else stringResource(R.string.favorite_alt),
                         tint = MaterialTheme.colors.primary
                     )
                 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -1,8 +1,9 @@
 package com.abhiek.ezrecipes.ui.search
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -25,7 +26,6 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun SearchResults(
     recipes: List<Recipe>,
@@ -33,9 +33,7 @@ fun SearchResults(
     onNavigateToRecipe: () -> Unit
 ) {
     Column(
-        modifier = Modifier
-            .padding(8.dp)
-            .verticalScroll(rememberScrollState())
+        modifier = Modifier.padding(8.dp)
     ) {
         Text(
             text = stringResource(R.string.results_title),
@@ -46,14 +44,15 @@ fun SearchResults(
             modifier = Modifier.fillMaxWidth()
         )
 
-        FlowRow(
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(minSize = 350.dp),
             modifier = Modifier
                 .padding(8.dp)
                 .fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            recipes.forEach { recipe ->
+            items(recipes) { recipe ->
                 RecipeCard(recipe) {
                     mainViewModel.recipe = recipe
                     onNavigateToRecipe()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.models.Recipe
@@ -30,10 +32,11 @@ import com.abhiek.ezrecipes.utils.Constants
 fun SearchResults(
     recipes: List<Recipe>,
     mainViewModel: MainViewModel,
+    modifier: Modifier = Modifier,
     onNavigateToRecipe: () -> Unit
 ) {
     Column(
-        modifier = Modifier.padding(8.dp)
+        modifier = modifier.padding(8.dp)
     ) {
         Text(
             text = stringResource(R.string.results_title),
@@ -43,6 +46,20 @@ fun SearchResults(
             ),
             modifier = Modifier.fillMaxWidth()
         )
+
+        // Should only be visible on large screens
+        if (recipes.isEmpty()) {
+            // Center vertically & horizontally
+            Text(
+                text = stringResource(R.string.results_placeholder),
+                style = MaterialTheme.typography.h6.copy(
+                    textAlign = TextAlign.Center
+                ),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .wrapContentHeight(Alignment.CenterVertically)
+            )
+        }
 
         LazyVerticalGrid(
             columns = GridCells.Adaptive(minSize = 350.dp),
@@ -62,22 +79,31 @@ fun SearchResults(
     }
 }
 
+private class SearchResultsPreviewParameterProvider: PreviewParameterProvider<List<Recipe>> {
+    override val values = sequenceOf(
+        listOf(),
+        listOf(
+            Constants.Mocks.PINEAPPLE_SALAD,
+            Constants.Mocks.CHOCOLATE_CUPCAKE,
+            Constants.Mocks.THAI_BASIL_CHICKEN
+        )
+    )
+}
+
 @DevicePreviews
 @DisplayPreviews
 @FontPreviews
 @OrientationPreviews
 @Composable
-private fun SearchResultsPreview() {
+private fun SearchResultsPreview(
+    @PreviewParameter(SearchResultsPreviewParameterProvider::class) recipes: List<Recipe>
+) {
     val recipeService = MockRecipeService
     val viewModel = MainViewModel(RecipeRepository(recipeService))
 
     EZRecipesTheme {
         Surface {
-            SearchResults(listOf(
-                Constants.Mocks.PINEAPPLE_SALAD,
-                Constants.Mocks.CHOCOLATE_CUPCAKE,
-                Constants.Mocks.THAI_BASIL_CHICKEN
-            ), viewModel) {}
+            SearchResults(recipes, viewModel) {}
         }
     }
 }

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -105,4 +105,5 @@
     <string name="no_results">No recipes found</string>
 
     <string name="results_title">Results</string>
+    <string name="results_placeholder">Use the filters to search for your favorite recipes!</string>
 </resources>

--- a/EZRecipes/gradle.properties
+++ b/EZRecipes/gradle.properties
@@ -25,3 +25,5 @@ android.nonTransitiveRClass=true
 org.gradle.warning.mode=all
 # Enable configuration cache for faster builds
 org.gradle.configuration-cache=true
+# Keep the app installed after running instrumented tests
+#android.injected.androidTest.leaveApksInstalledAfterRun=true


### PR DESCRIPTION
![image](https://github.com/Abhiek187/ez-recipes-android/assets/29958092/68f1033b-ed7d-4fa5-a236-7549d0ed5bd0)

![image](https://github.com/Abhiek187/ez-recipes-android/assets/29958092/18ae0b80-39cb-43bb-a1fa-4e0a9528e2d2)

I made the filter form more responsive on larger screens. Now we can display both the form and the results side-by-side by combining them in one route. Each screen size can be tested on a foldable by closing it (compact), opening it in portrait (medium), and landscape (expanded).

I tested the release build in advance and (as expected) ran into a Proguard issue that was thankfully easy to resolve.

The instrumented tests seemed simple at first, but I ran into a lot of weird issues while testing on large screens. First, I had trouble clicking on the navigation drawer when the text was in a clickable row (despite checkboxes designed the way, but work just fine). Then I had issues closing the dropdown menus to prevent them from overlapping each other. But I was eventually able to come up with small fixes for all of them. So now I can collect screenshots on any device.

This completes https://github.com/Abhiek187/ez-recipes-web/issues/205 and https://github.com/Abhiek187/ez-recipes-web/issues/8 for Android. The last thing I need to do is collect new screenshots and create a new version on the Play Store if all goes well.