### PR TITLE
Feature/paginate

### DIFF
--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     val material3Version = "1.2.1"
     val retrofitVersion = "2.11.0"
     val jupiterVersion = "5.10.2"
-    val espressoVersion = "3.5.1"
+    val espressoVersion = "3.6.1"
 
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     implementation("androidx.core:core-ktx:1.13.1")
@@ -107,7 +107,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.5")
 
     androidTestImplementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:$espressoVersion")
     androidTestImplementation("androidx.test.espresso:espresso-intents:$espressoVersion")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Recipe.kt
@@ -1,6 +1,7 @@
 package com.abhiek.ezrecipes.data.models
 
 data class Recipe(
+    val _id: String?,
     val id: Int,
     val name: String,
     val url: String?,
@@ -22,5 +23,6 @@ data class Recipe(
     val culture: List<Cuisine>,
     val nutrients: List<Nutrient>,
     val ingredients: List<Ingredient>,
-    val instructions: List<Instruction>
+    val instructions: List<Instruction>,
+    var token: String? = null // searchSequenceToken for pagination
 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecipeFilter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecipeFilter.kt
@@ -17,7 +17,8 @@ data class RecipeFilter(
     var sustainable: Boolean = false,
     var spiceLevel: List<SpiceLevel> = listOf(),
     var type: List<MealType> = listOf(),
-    var culture: List<Cuisine> = listOf()
+    var culture: List<Cuisine> = listOf(),
+    var token: String? = null // either an ObjectId or searchSequenceToken for pagination
 ) {
     fun toMap(): Map<String, Any> {
         // Filter all the keys that aren't defined separately in the service

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -124,8 +124,8 @@ fun NavigationGraph(
                         modifier = Modifier.weight(1f)
                     ) {}
                     SearchResults(
-                        searchViewModel.recipes,
                         mainViewModel,
+                        searchViewModel,
                         modifier = Modifier.weight(
                             if (widthSizeClass == WindowWidthSizeClass.Medium) 1f else 2f
                         )
@@ -148,7 +148,7 @@ fun NavigationGraph(
             popEnterTransition = { slideRightEnter() },
             popExitTransition = { slideRightExit() }
         ) {
-            SearchResults(searchViewModel.recipes, mainViewModel) {
+            SearchResults(mainViewModel, searchViewModel) {
                 navController.navigate(
                     Constants.Routes.RECIPE.replace(
                         "{id}", mainViewModel.recipe?.id.toString()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -64,34 +64,39 @@ fun SearchResults(
             )
         }
 
-        LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = 350.dp),
-            modifier = Modifier
-                .padding(8.dp)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth()
         ) {
-            items(searchViewModel.recipes) { recipe ->
-                RecipeCard(recipe) {
-                    mainViewModel.recipe = recipe
-                    onNavigateToRecipe()
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(minSize = 350.dp),
+                modifier = Modifier
+                    .padding(8.dp)
+                    .weight(1f), // occupy remaining space when loader isn't visible
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(searchViewModel.recipes) { recipe ->
+                    RecipeCard(recipe) {
+                        mainViewModel.recipe = recipe
+                        onNavigateToRecipe()
+                    }
                 }
-            }
-            // Invisible detector when the user scrolls to the bottom of the list
-            // https://stackoverflow.com/a/71875618
-            item {
-                LaunchedEffect(true) {
-                    // Prevent multiple requests from running at once
-                    if (searchViewModel.lastToken != null && !searchViewModel.isLoading) {
-                        searchViewModel.searchRecipes(paginate = true)
+                // Invisible detector when the user scrolls to the bottom of the list
+                // https://stackoverflow.com/a/71875618
+                item {
+                    LaunchedEffect(true) {
+                        // Prevent multiple requests from running at once
+                        if (searchViewModel.lastToken != null && !searchViewModel.isLoading) {
+                            searchViewModel.searchRecipes(paginate = true)
+                        }
                     }
                 }
             }
-        }
 
-        if (searchViewModel.isLoading && searchViewModel.lastToken != null) {
-            CircularProgressIndicator()
+            if (searchViewModel.isLoading && searchViewModel.lastToken != null) {
+                CircularProgressIndicator()
+            }
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -4,10 +4,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -30,8 +32,8 @@ import com.abhiek.ezrecipes.utils.Constants
 
 @Composable
 fun SearchResults(
-    recipes: List<Recipe>,
     mainViewModel: MainViewModel,
+    searchViewModel: SearchViewModel,
     modifier: Modifier = Modifier,
     onNavigateToRecipe: () -> Unit
 ) {
@@ -48,7 +50,7 @@ fun SearchResults(
         )
 
         // Should only be visible on large screens
-        if (recipes.isEmpty()) {
+        if (searchViewModel.recipes.isEmpty()) {
             // Center vertically & horizontally
             Text(
                 text = stringResource(R.string.results_placeholder),
@@ -61,19 +63,35 @@ fun SearchResults(
             )
         }
 
-        LazyVerticalGrid(
-            columns = GridCells.Adaptive(minSize = 350.dp),
-            modifier = Modifier
-                .padding(8.dp)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            items(recipes) { recipe ->
-                RecipeCard(recipe) {
-                    mainViewModel.recipe = recipe
-                    onNavigateToRecipe()
+        Column {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(minSize = 350.dp),
+                modifier = Modifier
+                    .padding(8.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(searchViewModel.recipes) { recipe ->
+                    RecipeCard(recipe) {
+                        mainViewModel.recipe = recipe
+                        onNavigateToRecipe()
+                    }
                 }
+                // Invisible detector when the user scrolls to the bottom of the list
+                // https://stackoverflow.com/a/71875618
+                item {
+                    LaunchedEffect(true) {
+                        // Prevent multiple requests from running at once
+                        if (searchViewModel.lastToken != null && !searchViewModel.isLoading) {
+                            searchViewModel.searchRecipes(paginate = true)
+                        }
+                    }
+                }
+            }
+
+            if (searchViewModel.isLoading) {
+                CircularProgressIndicator()
             }
         }
     }
@@ -99,11 +117,13 @@ private fun SearchResultsPreview(
     @PreviewParameter(SearchResultsPreviewParameterProvider::class) recipes: List<Recipe>
 ) {
     val recipeService = MockRecipeService
-    val viewModel = MainViewModel(RecipeRepository(recipeService))
+    val recipeViewModel = MainViewModel(RecipeRepository(recipeService))
+    val searchViewModel = SearchViewModel(RecipeRepository((recipeService)))
+    searchViewModel.recipes = recipes
 
     EZRecipesTheme {
         Surface {
-            SearchResults(recipes, viewModel) {}
+            SearchResults(recipeViewModel, searchViewModel) {}
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -38,6 +38,7 @@ fun SearchResults(
     onNavigateToRecipe: () -> Unit
 ) {
     Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.padding(8.dp)
     ) {
         Text(
@@ -63,36 +64,34 @@ fun SearchResults(
             )
         }
 
-        Column {
-            LazyVerticalGrid(
-                columns = GridCells.Adaptive(minSize = 350.dp),
-                modifier = Modifier
-                    .padding(8.dp)
-                    .fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(searchViewModel.recipes) { recipe ->
-                    RecipeCard(recipe) {
-                        mainViewModel.recipe = recipe
-                        onNavigateToRecipe()
-                    }
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(minSize = 350.dp),
+            modifier = Modifier
+                .padding(8.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(searchViewModel.recipes) { recipe ->
+                RecipeCard(recipe) {
+                    mainViewModel.recipe = recipe
+                    onNavigateToRecipe()
                 }
-                // Invisible detector when the user scrolls to the bottom of the list
-                // https://stackoverflow.com/a/71875618
-                item {
-                    LaunchedEffect(true) {
-                        // Prevent multiple requests from running at once
-                        if (searchViewModel.lastToken != null && !searchViewModel.isLoading) {
-                            searchViewModel.searchRecipes(paginate = true)
-                        }
+            }
+            // Invisible detector when the user scrolls to the bottom of the list
+            // https://stackoverflow.com/a/71875618
+            item {
+                LaunchedEffect(true) {
+                    // Prevent multiple requests from running at once
+                    if (searchViewModel.lastToken != null && !searchViewModel.isLoading) {
+                        searchViewModel.searchRecipes(paginate = true)
                     }
                 }
             }
+        }
 
-            if (searchViewModel.isLoading) {
-                CircularProgressIndicator()
-            }
+        if (searchViewModel.isLoading && searchViewModel.lastToken != null) {
+            CircularProgressIndicator()
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchViewModel.kt
@@ -49,7 +49,8 @@ class SearchViewModel(
                     }
 
                     recipeError = null
-                    isRecipeLoaded = recipes.isNotEmpty()
+                    // isRecipeLoaded only applies when waiting for SearchResults from FilterForm
+                    isRecipeLoaded = !paginate && recipes.isNotEmpty()
                     noRecipesFound = recipes.isEmpty()
                     // Prevent subsequent calls if there are no more results
                     lastToken = result.response.lastOrNull()?.token

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -34,6 +34,7 @@ object Constants {
     object Mocks {
         //region Normal, no culture
         val PINEAPPLE_SALAD = Recipe(
+            _id = "65dd4e615d5abcc9dc113038",
             id = 635562,
             name = "Blueberry-Pineapple Salad",
             url = "https://spoonacular.com/blueberry-pineapple-salad-635562",
@@ -125,6 +126,7 @@ object Constants {
         //endregion
         //region Contains instruction name & culture
         val CHOCOLATE_CUPCAKE = Recipe(
+            _id = "65bfe0fde939d8f4ebff712f",
             id = 644783,
             name = "Gluten And Dairy Free Chocolate Cupcakes",
             url = "https://spoonacular.com/gluten-and-dairy-free-chocolate-cupcakes-644783",
@@ -346,6 +348,7 @@ object Constants {
         //endregion
         //region Spicy, more culture & types
         val THAI_BASIL_CHICKEN = Recipe(
+            _id = "65bb6a8de939d8f4eba23cf0",
             id = 663074,
             name = "Thai Basil Chicken With Green Curry",
             url = "https://spoonacular.com/thai-basil-chicken-with-green-curry-663074",


### PR DESCRIPTION
<img src="https://github.com/Abhiek187/ez-recipes-android/assets/29958092/b4e2b2b0-ca22-4048-ba96-69e18ec3cd55" alt="search results with loader at the bottom" width="300">

_The Android implementation of https://github.com/Abhiek187/ez-recipes-server/issues/199_

I was able to copy-paste most of the logic from the iOS/web app to paginate search results using a token parameter. The only issues I encountered were trying to position the loader properly without it cutting off at the bottom and fixing a back button bug when loading additional results. Side effects be like that sometimes. `useEffect, onAppear, LaunchedEffect` 🤷