### PR TITLE
Feature/recent recipes

### DIFF
--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -4,6 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -69,10 +70,11 @@ android {
 
 dependencies {
     val composeBomVersion = "2024.06.00"
-    val lifecycleVersion = "2.8.2"
+    val lifecycleVersion = "2.8.3"
     val materialVersion = "1.6.8"
     val material3Version = "1.2.1"
     val retrofitVersion = "2.11.0"
+    val roomVersion = "2.6.1"
     val jupiterVersion = "5.10.3"
     val espressoVersion = "3.6.1"
 
@@ -98,6 +100,11 @@ dependencies {
     implementation("com.squareup.retrofit2:retrofit")
     implementation("com.squareup.retrofit2:converter-gson")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+    // Room
+    implementation("androidx.room:room-runtime:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+    annotationProcessor("androidx.room:room-compiler:$roomVersion")
+    ksp("androidx.room:room-compiler:$roomVersion")
 
     testImplementation(platform("org.junit:junit-bom:$jupiterVersion"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -124,6 +124,11 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
 
+ksp {
+    // Export the Room schema to be version controlled (but not included in the build)
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 // Log Gradle test results
 tasks.withType<Test> {
     useJUnitPlatform() // enable JUnit 5 (Jupiter)

--- a/EZRecipes/app/schemas/com.abhiek.ezrecipes.data.storage.AppDatabase/1.json
+++ b/EZRecipes/app/schemas/com.abhiek.ezrecipes.data.storage.AppDatabase/1.json
@@ -1,0 +1,46 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "3998e1914beb027b36f48707766fde11",
+    "entities": [
+      {
+        "tableName": "RecentRecipe",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `recipe` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipe",
+            "columnName": "recipe",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3998e1914beb027b36f48707766fde11')"
+    ]
+  }
+}

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.abhiek.ezrecipes.ui.MainActivity
 import com.abhiek.ezrecipes.ui.MainLayout
@@ -38,9 +39,11 @@ internal class EZRecipesInstrumentedTest {
     private val extras = InstrumentationRegistry.getArguments()
     private val isLocal = extras.getString("ci") != "true"
 
-    private fun screenshot(name: String, shotNum: Int) {
+    private fun screenshot(name: String, shotNum: Int? = null) {
         if (isLocal) {
-            Screengrab.screenshot("$name-$shotNum")
+            var screenshotName = name
+            if (shotNum != null) screenshotName += "-$shotNum"
+            Screengrab.screenshot(screenshotName)
         }
     }
 
@@ -421,5 +424,22 @@ internal class EZRecipesInstrumentedTest {
         }
         screenshot("search-screen", shotNum)
         shotNum += 1
+    }
+
+    @SmallTest
+    @Test
+    fun testGlossaryScreen() {
+        // Take a screenshot of the glossary tab (no assertions)
+        val hamburgerMenu = composeTestRule
+            .onNodeWithContentDescription(activity.getString(R.string.hamburger_menu_alt))
+
+        if (hamburgerMenu.isDisplayed()) {
+            hamburgerMenu.performClick()
+        }
+
+        val glossaryTab = composeTestRule
+            .onNodeWithText(activity.getString(R.string.glossary_tab))
+        glossaryTab.performClick()
+        screenshot("glossary-view")
     }
 }

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/MainDispatcherRule.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/MainDispatcherRule.kt
@@ -1,0 +1,26 @@
+package com.abhiek.ezrecipes
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+// Reusable JUnit4 Rule to override the Main dispatcher (used in viewModelScope)
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/MainDispatcherRule.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/MainDispatcherRule.kt
@@ -15,12 +15,10 @@ class MainDispatcherRule(
     private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
 ) : TestWatcher() {
     override fun starting(description: Description?) {
-        super.starting(description)
         Dispatchers.setMain(testDispatcher)
     }
 
     override fun finished(description: Description?) {
-        super.finished(description)
         Dispatchers.resetMain()
     }
 }

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
@@ -73,24 +73,7 @@ internal class RecipeRepositoryTest {
         // When fetchRecentRecipes() is called
         val recentRecipes = recipeRepository.fetchRecentRecipes()
 
-//        println("viewModel.recentRecipes.map { it.recipe }.toTypedArray(): " + viewModel.recentRecipes.map { it.recipe }.toTypedArray().)
-//        println("mockService.recipes.toTypedArray(): " + mockService.recipes.toTypedArray())
-//        println("viewModel.recentRecipes.map { it.recipe }.sortedBy { it.id }: " + viewModel.recentRecipes.map { it.recipe }.sortedBy { it.id })
-//        println("mockService.recipes.sortedBy { it.id }: " + mockService.recipes.sortedBy { it.id })
-
         // Then recentRecipes should return the mock recipes
-//        assertArrayEquals(
-//            recentRecipes.map { it.recipe }.toTypedArray(),
-//            mockService.recipes.toTypedArray()
-//        )
-//        assertArrayEquals(
-//            viewModel.recentRecipes.map { it.recipe }.toTypedArray(),
-//            mockService.recipes.toTypedArray()
-//        )
-//        assertEquals(
-//            viewModel.recentRecipes.map { it.recipe }.sortedBy { it.id },
-//            mockService.recipes.sortedBy { it.id }
-//        )
         assertEquals(
             recentRecipes.map { it.recipe }.sortedBy { it.id },
             mockService.recipes.sortedBy { it.id }

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
@@ -50,7 +50,7 @@ internal class RecipeRepositoryTest {
 
     @After
     fun tearDown() {
-        db.close()
+        db.clearAllTables()
     }
 
     @Test

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
@@ -1,4 +1,4 @@
-package com.abhiek.ezrecipes.ui
+package com.abhiek.ezrecipes.data.recipe
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
@@ -6,8 +6,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.abhiek.ezrecipes.MainDispatcherRule
 import com.abhiek.ezrecipes.data.models.RecentRecipe
 import com.abhiek.ezrecipes.data.models.Recipe
-import com.abhiek.ezrecipes.data.recipe.MockRecipeService
-import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.storage.AppDatabase
 import com.abhiek.ezrecipes.data.storage.RecentRecipeDao
 import com.abhiek.ezrecipes.utils.Constants
@@ -20,11 +18,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-internal class MainViewModelTest {
+internal class RecipeRepositoryTest {
     private lateinit var recentRecipeDao: RecentRecipeDao
     private lateinit var db: AppDatabase
     private lateinit var mockService: MockRecipeService
-    private lateinit var viewModel: MainViewModel
+    private lateinit var recipeRepository: RecipeRepository
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
@@ -47,7 +45,7 @@ internal class MainViewModelTest {
         recentRecipeDao = db.recentRecipeDao()
 
         mockService = MockRecipeService
-        viewModel = MainViewModel(RecipeRepository(mockService), recentRecipeDao)
+        recipeRepository = RecipeRepository(mockService, recentRecipeDao)
     }
 
     @After
@@ -61,10 +59,10 @@ internal class MainViewModelTest {
         prepopulateDatabase(listOf())
 
         // When fetchRecentRecipes() is called
-        viewModel.fetchRecentRecipes()
+        val recentRecipes = recipeRepository.fetchRecentRecipes()
 
         // Then recentRecipes should return an empty list
-        assertTrue(viewModel.recentRecipes.isEmpty())
+        assertTrue(recentRecipes.isEmpty())
     }
 
     @Test
@@ -73,8 +71,7 @@ internal class MainViewModelTest {
         prepopulateDatabase(mockService.recipes)
 
         // When fetchRecentRecipes() is called
-//        viewModel.fetchRecentRecipes()
-        val recentRecipes = recentRecipeDao.getAll()
+        val recentRecipes = recipeRepository.fetchRecentRecipes()
 
 //        println("viewModel.recentRecipes.map { it.recipe }.toTypedArray(): " + viewModel.recentRecipes.map { it.recipe }.toTypedArray().)
 //        println("mockService.recipes.toTypedArray(): " + mockService.recipes.toTypedArray())
@@ -106,7 +103,7 @@ internal class MainViewModelTest {
         prepopulateDatabase(mockService.recipes)
 
         // When a new recipe is added
-        viewModel.saveRecentRecipe(mockService.recipes[0].copy(id = 2))
+        recipeRepository.saveRecentRecipe(mockService.recipes[0].copy(id = 2))
 
         // Then the number of recipes should increase by 1
         assertEquals(recentRecipeDao.getAll().size, mockService.recipes.size + 1)
@@ -121,7 +118,7 @@ internal class MainViewModelTest {
         prepopulateDatabase(recipes)
 
         // When a new recipe is added
-        viewModel.saveRecentRecipe(mockService.recipes[0])
+        recipeRepository.saveRecentRecipe(mockService.recipes[0])
 
         // Then the oldest recipe is deleted
         assertEquals(recentRecipeDao.getAll().size, Constants.MAX_RECENT_RECIPES)
@@ -134,7 +131,7 @@ internal class MainViewModelTest {
         val oldTimestamp = recentRecipeDao.getRecipeById(mockService.recipes[0].id)?.timestamp ?: -1
 
         // When an existing recipe is added
-        viewModel.saveRecentRecipe(mockService.recipes[0])
+        recipeRepository.saveRecentRecipe(mockService.recipes[0])
 
         // Then its timestamp is updated
         val newTimestamp = recentRecipeDao.getRecipeById(mockService.recipes[0].id)?.timestamp ?: -1

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/data/recipe/RecipeRepositoryTest.kt
@@ -42,6 +42,8 @@ internal class RecipeRepositoryTest {
     fun setUp() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = AppDatabase.getInstance(context, inMemory = true)
+        // Clear any data stored from previous instrumented tests
+        db.clearAllTables()
         recentRecipeDao = db.recentRecipeDao()
 
         mockService = MockRecipeService

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
@@ -1,0 +1,105 @@
+package com.abhiek.ezrecipes.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.abhiek.ezrecipes.MainDispatcherRule
+import com.abhiek.ezrecipes.data.models.RecentRecipe
+import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.recipe.MockRecipeService
+import com.abhiek.ezrecipes.data.recipe.RecipeRepository
+import com.abhiek.ezrecipes.data.storage.AppDatabase
+import com.abhiek.ezrecipes.data.storage.RecentRecipeDao
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class MainViewModelTest {
+    private lateinit var recentRecipeDao: RecentRecipeDao
+    private lateinit var db: AppDatabase
+    private lateinit var mockService: MockRecipeService
+    private lateinit var viewModel: MainViewModel
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private suspend fun prepopulateDatabase(recipes: List<Recipe>) {
+        recipes.forEach { recipe ->
+            val recentRecipe = RecentRecipe(
+                id = recipe.id,
+                timestamp = System.currentTimeMillis(),
+                recipe = recipe
+            )
+            recentRecipeDao.insert(recentRecipe)
+        }
+    }
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = AppDatabase.getInstance(context, inMemory = true)
+        recentRecipeDao = db.recentRecipeDao()
+
+        mockService = MockRecipeService
+        viewModel = MainViewModel(RecipeRepository(mockService), recentRecipeDao)
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun fetchRecentRecipesEmpty() = runTest {
+        // Given an empty database
+        prepopulateDatabase(listOf())
+
+        // When fetchRecentRecipes() is called
+        viewModel.fetchRecentRecipes()
+
+        // Then recentRecipes should return an empty list
+        assertTrue(viewModel.recentRecipes.isEmpty())
+    }
+
+    @Test
+    fun fetchRecentRecipesNotEmpty() = runTest {
+        // Given a database with mock recipes
+        prepopulateDatabase(mockService.recipes)
+
+        // When fetchRecentRecipes() is called
+//        viewModel.fetchRecentRecipes()
+        val recentRecipes = recentRecipeDao.getAll()
+
+//        println("viewModel.recentRecipes.map { it.recipe }.toTypedArray(): " + viewModel.recentRecipes.map { it.recipe }.toTypedArray().)
+//        println("mockService.recipes.toTypedArray(): " + mockService.recipes.toTypedArray())
+//        println("viewModel.recentRecipes.map { it.recipe }.sortedBy { it.id }: " + viewModel.recentRecipes.map { it.recipe }.sortedBy { it.id })
+//        println("mockService.recipes.sortedBy { it.id }: " + mockService.recipes.sortedBy { it.id })
+
+        // Then recentRecipes should return the mock recipes
+//        assertArrayEquals(
+//            recentRecipes.map { it.recipe }.toTypedArray(),
+//            mockService.recipes.toTypedArray()
+//        )
+//        assertArrayEquals(
+//            viewModel.recentRecipes.map { it.recipe }.toTypedArray(),
+//            mockService.recipes.toTypedArray()
+//        )
+//        assertEquals(
+//            viewModel.recentRecipes.map { it.recipe }.sortedBy { it.id },
+//            mockService.recipes.sortedBy { it.id }
+//        )
+        assertEquals(
+            recentRecipes.map { it.recipe }.sortedBy { it.id },
+            mockService.recipes.sortedBy { it.id }
+        )
+    }
+
+    @Test
+    fun saveRecentRecipe() {
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecentRecipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecentRecipe.kt
@@ -1,0 +1,12 @@
+package com.abhiek.ezrecipes.data.models
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.abhiek.ezrecipes.utils.Constants
+
+@Entity(tableName = Constants.Room.RECENT_RECIPE_TABLE)
+data class RecentRecipe(
+    @PrimaryKey val id: Int, // extract id from recipe to detect duplicates
+    val timestamp: Long,
+    val recipe: String
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecentRecipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecentRecipe.kt
@@ -7,6 +7,6 @@ import com.abhiek.ezrecipes.utils.Constants
 @Entity(tableName = Constants.Room.RECENT_RECIPE_TABLE)
 data class RecentRecipe(
     @PrimaryKey val id: Int, // extract id from recipe to detect duplicates
-    val timestamp: Long,
-    val recipe: String
+    var timestamp: Long,
+    val recipe: Recipe
 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/AppDatabase.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/AppDatabase.kt
@@ -16,10 +16,22 @@ abstract class AppDatabase: RoomDatabase() {
     companion object {
         private lateinit var db: AppDatabase
 
-        // Initialize the Room database when first referencing the singleton
-        // Room stored at /data/data/PACKAGE-NAME/database
-        fun getInstance(context: Context): AppDatabase {
+        /**
+         * Initialize the Room database
+         *
+         * Note: Room stored at /data/data/PACKAGE-NAME/databases
+         *
+         * @param context the application context
+         * @param inMemory if true, use an in-memory database
+         * @return a database instance
+         */
+        fun getInstance(context: Context, inMemory: Boolean = false): AppDatabase {
             return if (Companion::db.isInitialized) {
+                db
+            } else if (inMemory) {
+                db = Room.inMemoryDatabaseBuilder(
+                    context, AppDatabase::class.java
+                ).build()
                 db
             } else {
                 db = Room.databaseBuilder(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/AppDatabase.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/AppDatabase.kt
@@ -8,7 +8,7 @@ import androidx.room.TypeConverters
 import com.abhiek.ezrecipes.data.models.RecentRecipe
 import com.abhiek.ezrecipes.utils.Constants
 
-@Database(entities = [RecentRecipe::class], version = 1)
+@Database(entities = [RecentRecipe::class], version = Constants.Room.DATABASE_VERSION)
 @TypeConverters(Converters::class)
 abstract class AppDatabase: RoomDatabase() {
     abstract fun recentRecipeDao(): RecentRecipeDao

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/AppDatabase.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/AppDatabase.kt
@@ -1,0 +1,32 @@
+package com.abhiek.ezrecipes.data.storage
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.abhiek.ezrecipes.data.models.RecentRecipe
+import com.abhiek.ezrecipes.utils.Constants
+
+@Database(entities = [RecentRecipe::class], version = 1)
+@TypeConverters(Converters::class)
+abstract class AppDatabase: RoomDatabase() {
+    abstract fun recentRecipeDao(): RecentRecipeDao
+
+    companion object {
+        private lateinit var db: AppDatabase
+
+        // Initialize the Room database when first referencing the singleton
+        // Room stored at /data/data/PACKAGE-NAME/database
+        fun getInstance(context: Context): AppDatabase {
+            return if (Companion::db.isInitialized) {
+                db
+            } else {
+                db = Room.databaseBuilder(
+                    context, AppDatabase::class.java, Constants.Room.DATABASE_NAME
+                ).build()
+                db
+            }
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/Converters.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/Converters.kt
@@ -1,0 +1,30 @@
+package com.abhiek.ezrecipes.data.storage
+
+import android.util.Log
+import androidx.room.TypeConverter
+import com.abhiek.ezrecipes.data.models.Recipe
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+
+class Converters {
+    val gson = Gson()
+
+    companion object {
+        private const val TAG = "Converters"
+    }
+
+    @TypeConverter
+    fun fromRecipeString(recipeStr: String?): Recipe? {
+        try {
+            return gson.fromJson(recipeStr, Recipe::class.java)
+        } catch (error: JsonSyntaxException) {
+            Log.w(TAG, "Failed to parse recipe string: $recipeStr")
+            return null
+        }
+    }
+
+    @TypeConverter
+    fun recipeToString(recipe: Recipe?): String? {
+        return gson.toJson(recipe)
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/Converters.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/Converters.kt
@@ -19,6 +19,7 @@ class Converters {
             return gson.fromJson(recipeStr, Recipe::class.java)
         } catch (error: JsonSyntaxException) {
             Log.w(TAG, "Failed to parse recipe string: $recipeStr")
+            Log.w(TAG, "Error: ${error.localizedMessage}")
             return null
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/RecentRecipeDao.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/RecentRecipeDao.kt
@@ -1,0 +1,17 @@
+package com.abhiek.ezrecipes.data.storage
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.abhiek.ezrecipes.data.models.RecentRecipe
+import com.abhiek.ezrecipes.utils.Constants
+
+@Dao
+interface RecentRecipeDao {
+    @Query("SELECT * FROM ${Constants.Room.RECENT_RECIPE_TABLE} ORDER BY timestamp DESC")
+    suspend fun getAll(): List<RecentRecipe>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(recentRecipe: RecentRecipe)
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/RecentRecipeDao.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/RecentRecipeDao.kt
@@ -1,17 +1,20 @@
 package com.abhiek.ezrecipes.data.storage
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 import com.abhiek.ezrecipes.data.models.RecentRecipe
 import com.abhiek.ezrecipes.utils.Constants
 
 @Dao
 interface RecentRecipeDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(recentRecipe: RecentRecipe)
+
     @Query("SELECT * FROM ${Constants.Room.RECENT_RECIPE_TABLE} ORDER BY timestamp DESC")
     suspend fun getAll(): List<RecentRecipe>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(recentRecipe: RecentRecipe)
+    @Query("SELECT * FROM ${Constants.Room.RECENT_RECIPE_TABLE} WHERE id = :id")
+    suspend fun getRecipeById(id: Int): RecentRecipe?
+
+    @Delete
+    suspend fun delete(recentRecipe: RecentRecipe)
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -5,16 +5,20 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.abhiek.ezrecipes.data.models.RecentRecipe
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.recipe.RecipeResult
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.models.RecipeError
+import com.abhiek.ezrecipes.data.storage.RecentRecipeDao
+import com.abhiek.ezrecipes.utils.Constants
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 // Connects the View to the Repository
 class MainViewModel(
-    private val recipeRepository: RecipeRepository
+    private val recipeRepository: RecipeRepository,
+    private val recentRecipeDao: RecentRecipeDao
 ): ViewModel() {
     // Only expose a read-only copy of the state to the View
     var job by mutableStateOf<Job?>(null)
@@ -39,6 +43,8 @@ class MainViewModel(
                 recipeError = null
                 isRecipeLoaded = fromHome
                 showRecipeAlert = false
+
+                saveRecentRecipe(result.response)
             }
             is RecipeResult.Error -> {
                 recipe = null
@@ -67,6 +73,34 @@ class MainViewModel(
             isLoading = false
 
             updateRecipeProps(response, fromHome)
+        }
+    }
+
+    private fun saveRecentRecipe(recipe: Recipe) {
+        viewModelScope.launch {
+            // If the recipe already exists, replace the timestamp with the current time
+            val existingRecipe = recentRecipeDao.getRecipeById(recipe.id)
+
+            if (existingRecipe != null) {
+                existingRecipe.timestamp = System.currentTimeMillis()
+                recentRecipeDao.insert(existingRecipe)
+                return@launch
+            }
+
+            // If there are too many recipes, delete the oldest recipe
+            val recipes = recentRecipeDao.getAll()
+
+            if (recipes.size >= Constants.MAX_RECENT_RECIPES) {
+                val oldestRecipe = recipes.last()
+                recentRecipeDao.delete(oldestRecipe)
+            }
+
+            val newRecipe = RecentRecipe(
+                id = recipe.id,
+                timestamp = System.currentTimeMillis(),
+                recipe = recipe
+            )
+            recentRecipeDao.insert(newRecipe)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -31,6 +31,7 @@ class MainViewModel(
     // Alerts the home screen to navigate to the recipe screen
     var isRecipeLoaded by mutableStateOf(false)
     var showRecipeAlert by mutableStateOf(false)
+    var recentRecipes by mutableStateOf<List<RecentRecipe>>(listOf())
 
     private fun updateRecipeProps(
         result: RecipeResult<Recipe>,
@@ -73,6 +74,12 @@ class MainViewModel(
             isLoading = false
 
             updateRecipeProps(response, fromHome)
+        }
+    }
+
+    fun fetchRecentRecipes() {
+        viewModelScope.launch {
+            recentRecipes = recentRecipeDao.getAll()
         }
     }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -44,8 +44,6 @@ class MainViewModel(
                 recipeError = null
                 isRecipeLoaded = fromHome
                 showRecipeAlert = false
-
-                saveRecentRecipe(result.response)
             }
             is RecipeResult.Error -> {
                 recipe = null
@@ -83,7 +81,7 @@ class MainViewModel(
         }
     }
 
-    private fun saveRecentRecipe(recipe: Recipe) {
+    fun saveRecentRecipe(recipe: Recipe) {
         viewModelScope.launch {
             // If the recipe already exists, replace the timestamp with the current time
             val existingRecipe = recentRecipeDao.getRecipeById(recipe.id)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
@@ -1,19 +1,22 @@
 package com.abhiek.ezrecipes.ui
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.recipe.RecipeService
+import com.abhiek.ezrecipes.data.storage.AppDatabase
 
 // Required to initialize a ViewModel with a non-empty constructor
-class MainViewModelFactory: ViewModelProvider.Factory {
+class MainViewModelFactory(private val context: Context): ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
             return MainViewModel(
                 recipeRepository = RecipeRepository(
                     recipeService = RecipeService.instance
-                )
+                ),
+                recentRecipeDao = AppDatabase.getInstance(context).recentRecipeDao()
             ) as T
         }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
@@ -14,9 +14,9 @@ class MainViewModelFactory(private val context: Context): ViewModelProvider.Fact
         if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
             return MainViewModel(
                 recipeRepository = RecipeRepository(
-                    recipeService = RecipeService.instance
-                ),
-                recentRecipeDao = AppDatabase.getInstance(context).recentRecipeDao()
+                    recipeService = RecipeService.instance,
+                    recentRecipeDao = AppDatabase.getInstance(context).recentRecipeDao()
+                )
             ) as T
         }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -159,7 +159,8 @@ fun Home(
                             )
                         }
                     }
-                }
+                },
+                modifier = Modifier.padding(horizontal = 8.dp)
             )
         }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -1,5 +1,9 @@
 package com.abhiek.ezrecipes.ui.home
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -92,7 +96,7 @@ fun Home(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Button(
@@ -160,27 +164,38 @@ fun Home(
         }
 
         // Recently viewed recipes
-        if (mainViewModel.recentRecipes.isNotEmpty()) {
-            Text(
-                text = stringResource(R.string.recently_viewed),
-                style = MaterialTheme.typography.h4
+        // Smoothly fade in the recipe cards if they're slow to fetch from Room
+        AnimatedVisibility(
+            visible = mainViewModel.recentRecipes.isNotEmpty(),
+            enter = fadeIn(
+                tween(300, easing = LinearEasing)
             )
-            Divider()
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier
-                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                mainViewModel.recentRecipes.forEach { recentRecipe ->
-                    RecipeCard(
-                        recipe = recentRecipe.recipe,
-                        width = 350.dp
-                    ) {
-                        mainViewModel.recipe = recentRecipe.recipe
-                        onNavigateToRecipe()
+                Text(
+                    text = stringResource(R.string.recently_viewed),
+                    style = MaterialTheme.typography.h4
+                )
+                Divider()
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier
+                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                ) {
+                    mainViewModel.recentRecipes.forEach { recentRecipe ->
+                        RecipeCard(
+                            recipe = recentRecipe.recipe,
+                            width = 350.dp
+                        ) {
+                            mainViewModel.recipe = recentRecipe.recipe
+                            onNavigateToRecipe()
+                        }
                     }
                 }
             }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -45,6 +45,10 @@ fun Home(
     val defaultLoadingMessage = ""
     var loadingMessage by remember { mutableStateOf(defaultLoadingMessage) }
 
+    LaunchedEffect(Unit) {
+        mainViewModel.fetchRecentRecipes()
+    }
+
     LaunchedEffect(mainViewModel.isLoading) {
         // Don't show any messages initially if the recipe loads quickly
         loadingMessage = defaultLoadingMessage

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -170,6 +170,7 @@ fun Home(
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState())
             ) {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -236,7 +236,7 @@ private fun HomePreview(
     val recipeService = MockRecipeService
     val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
 
-    val viewModel = MainViewModel(RecipeRepository(recipeService), recentRecipeDao)
+    val viewModel = MainViewModel(RecipeRepository(recipeService, recentRecipeDao))
     val (isLoading, showAlert, recentRecipes) = state
     viewModel.isLoading = isLoading
     viewModel.showRecipeAlert = showAlert // show the fallback alert in the preview

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -92,7 +92,7 @@ fun Home(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Button(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -57,7 +57,6 @@ fun NavigationGraph(
     // Only call once when composed
     LaunchedEffect(Unit) {
         glossaryViewModel.checkCachedTerms()
-        mainViewModel.fetchRecentRecipes()
     }
 
     // Show the appropriate composable based on the current route, starting at the home screen

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -45,7 +45,7 @@ fun NavigationGraph(
     val isWideScreen = widthSizeClass == WindowWidthSizeClass.Expanded
 
     val mainViewModel = viewModel<MainViewModel>(
-        factory = MainViewModelFactory()
+        factory = MainViewModelFactory(context)
     )
     val searchViewModel = viewModel<SearchViewModel>(
         factory = SearchViewModelFactory()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -57,6 +57,7 @@ fun NavigationGraph(
     // Only call once when composed
     LaunchedEffect(Unit) {
         glossaryViewModel.checkCachedTerms()
+        mainViewModel.fetchRecentRecipes()
     }
 
     // Show the appropriate composable based on the current route, starting at the home screen

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -28,6 +29,12 @@ import com.abhiek.ezrecipes.utils.currentWindowSize
 
 @Composable
 fun Recipe(viewModel: MainViewModel, isWideScreen: Boolean, recipeIdString: String? = null) {
+    LaunchedEffect(viewModel.recipe) {
+        viewModel.recipe?.let { recipe ->
+            viewModel.saveRecentRecipe(recipe)
+        }
+    }
+
     if (viewModel.recipe == null) {
         // If this composable was opened due to a deep link, use the recipeId to load the recipe
         recipeIdString?.toIntOrNull()?.let { recipeId ->

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -138,7 +138,7 @@ private fun RecipePreview() {
     val context = LocalContext.current
     val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
 
-    val viewModel = MainViewModel(RecipeRepository(MockRecipeService), recentRecipeDao)
+    val viewModel = MainViewModel(RecipeRepository(MockRecipeService, recentRecipeDao))
     viewModel.getRandomRecipe()
     val windowSize = currentWindowSize()
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -11,11 +11,13 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
+import com.abhiek.ezrecipes.data.storage.AppDatabase
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -126,7 +128,10 @@ fun Recipe(viewModel: MainViewModel, isWideScreen: Boolean, recipeIdString: Stri
 @OrientationPreviews
 @Composable
 private fun RecipePreview() {
-    val viewModel = MainViewModel(RecipeRepository(MockRecipeService))
+    val context = LocalContext.current
+    val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
+
+    val viewModel = MainViewModel(RecipeRepository(MockRecipeService), recentRecipeDao)
     viewModel.getRandomRecipe()
     val windowSize = currentWindowSize()
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.abhiek.ezrecipes.R
@@ -26,7 +27,7 @@ import com.abhiek.ezrecipes.utils.boldAnnotatedString
 import kotlin.math.roundToInt
 
 @Composable
-fun RecipeCard(recipe: Recipe, onClick: () -> Unit) {
+fun RecipeCard(recipe: Recipe, width: Dp? = null, onClick: () -> Unit) {
     var isFavorite by remember { mutableStateOf(false) }
     val context = LocalContext.current
 
@@ -35,7 +36,8 @@ fun RecipeCard(recipe: Recipe, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .padding(8.dp)
-            .clickable { onClick() },
+            .clickable { onClick() }
+            .then(if (width != null) Modifier.width(width) else Modifier),
         elevation = 2.dp
     ) {
         Column(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -126,7 +126,7 @@ private fun SearchResultsPreview(
     val recipeService = MockRecipeService
     val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
 
-    val recipeViewModel = MainViewModel(RecipeRepository(recipeService), recentRecipeDao)
+    val recipeViewModel = MainViewModel(RecipeRepository(recipeService, recentRecipeDao))
     val searchViewModel = SearchViewModel(RecipeRepository((recipeService)))
     searchViewModel.recipes = recipes
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -22,6 +23,7 @@ import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
+import com.abhiek.ezrecipes.data.storage.AppDatabase
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -120,8 +122,11 @@ private class SearchResultsPreviewParameterProvider: PreviewParameterProvider<Li
 private fun SearchResultsPreview(
     @PreviewParameter(SearchResultsPreviewParameterProvider::class) recipes: List<Recipe>
 ) {
+    val context = LocalContext.current
     val recipeService = MockRecipeService
-    val recipeViewModel = MainViewModel(RecipeRepository(recipeService))
+    val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
+
+    val recipeViewModel = MainViewModel(RecipeRepository(recipeService), recentRecipeDao)
     val searchViewModel = SearchViewModel(RecipeRepository((recipeService)))
     searchViewModel.recipes = recipes
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SubmitButton.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SubmitButton.kt
@@ -98,7 +98,8 @@ fun SubmitButton(searchViewModel: SearchViewModel, enabled: Boolean) {
                             )
                         }
                     }
-                }
+                },
+                modifier = Modifier.padding(horizontal = 8.dp)
             )
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -34,6 +34,7 @@ object Constants {
 
     object Room {
         const val DATABASE_NAME = "AppDatabase"
+        const val DATABASE_VERSION = 1
         const val RECENT_RECIPE_TABLE = "RecentRecipe"
     }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -20,6 +20,7 @@ object Constants {
     const val MAX_CALS = 2000
 
     const val DATA_STORE_NAME = "data-store"
+    const val MAX_RECENT_RECIPES = 10
 
     object Routes {
         // tabs = user-facing labels, routes = internal "pretend" URL paths

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -31,6 +31,11 @@ object Constants {
         const val GLOSSARY = "glossary"
     }
 
+    object Room {
+        const val DATABASE_NAME = "AppDatabase"
+        const val RECENT_RECIPE_TABLE = "RecentRecipe"
+    }
+
     object Mocks {
         //region Normal, no culture
         val PINEAPPLE_SALAD = Recipe(

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
         <item>Mixing things up… 🥘</item>
         <item>Shaking things up… 🍲</item>
     </string-array>
+    <string name="recently_viewed">Recently Viewed</string>
 
     <!-- Recipe Screen -->
     <string name="no_recipe">No recipe loaded</string>

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
@@ -5,8 +5,8 @@ import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.storage.AppDatabase
 import com.abhiek.ezrecipes.data.storage.RecentRecipeDao
-import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MainDispatcherExtension::class)
+@ExtendWith(MockKExtension::class)
 internal class MainViewModelTest {
     private lateinit var mockService: MockRecipeService
     private lateinit var recentRecipeDao: RecentRecipeDao
@@ -24,11 +25,9 @@ internal class MainViewModelTest {
 
     @BeforeEach
     fun setUp() {
-        MockKAnnotations.init(this)
-
         mockService = MockRecipeService
         recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
-        viewModel = MainViewModel(RecipeRepository(mockService), recentRecipeDao)
+        viewModel = MainViewModel(RecipeRepository(mockService, recentRecipeDao))
     }
 
     @Test

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
@@ -1,7 +1,12 @@
 package com.abhiek.ezrecipes.ui
 
+import android.content.Context
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
+import com.abhiek.ezrecipes.data.storage.AppDatabase
+import com.abhiek.ezrecipes.data.storage.RecentRecipeDao
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -11,12 +16,19 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MainDispatcherExtension::class)
 internal class MainViewModelTest {
     private lateinit var mockService: MockRecipeService
+    private lateinit var recentRecipeDao: RecentRecipeDao
     private lateinit var viewModel: MainViewModel
+
+    @MockK
+    private lateinit var context: Context
 
     @BeforeEach
     fun setUp() {
+        MockKAnnotations.init(this)
+
         mockService = MockRecipeService
-        viewModel = MainViewModel(RecipeRepository(mockService))
+        recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
+        viewModel = MainViewModel(RecipeRepository(mockService), recentRecipeDao)
     }
 
     @Test

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/glossary/GlossaryViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/glossary/GlossaryViewModelTest.kt
@@ -7,6 +7,7 @@ import com.abhiek.ezrecipes.data.terms.MockTermsService
 import com.abhiek.ezrecipes.data.terms.TermsRepository
 import com.abhiek.ezrecipes.ui.MainDispatcherExtension
 import io.mockk.*
+import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(MainDispatcherExtension::class)
+@ExtendWith(MockKExtension::class)
 internal class GlossaryViewModelTest {
     private lateinit var mockTermsService: MockTermsService
     private lateinit var mockDataStoreService: DataStoreService

--- a/EZRecipes/build.gradle.kts
+++ b/EZRecipes/build.gradle.kts
@@ -1,5 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
+    val kotlinVersion = "1.9.22"
+
     id("com.android.application") version "8.5.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("org.jetbrains.kotlin.android") version kotlinVersion apply false
+    // Version must match Kotlin: https://github.com/google/ksp/releases
+    id("com.google.devtools.ksp") version "$kotlinVersion-1.0.17" apply false
 }


### PR DESCRIPTION
<div>
  <img src="https://github.com/Abhiek187/ez-recipes-android/assets/29958092/a599a4f3-d6b9-46f4-9313-1b13e8dc7b46" alt="recent-compact" width="300">
  <img src="https://github.com/Abhiek187/ez-recipes-android/assets/29958092/d934d2be-39b6-4571-819e-38d16b5b8d34" alt="recent-medium" width="300">
  <img src="https://github.com/Abhiek187/ez-recipes-android/assets/29958092/cda77993-9224-401f-8d65-dc62b831d92b" alt="recent-expanded" width="300">
</div>

_The Android implementation of https://github.com/Abhiek187/ez-recipes-web/issues/14_

Oh boy, this was another toughie. 😵

Modeling the data was easier than on iOS. It was just a matter of creating all the classes and constants needed to initialize Room. It was also easier to initialize an in-memory database for tests and previews than on iOS. I was able to use the trick from iOS where I could serialize the recipe object when stored in the DB since I only needed to reference the ID and a timestamp. That was also simple to implement (even compared to Retrofit) since I could just use GSON.

Querying and (especially) testing Room proved to be a challenge. Using an interface for the DAO (data access object) may look clean, but it forced me to rearchitect the read and write functions for the recent recipes. Since it's an interface, I can't define the logic for each function, other than the query itself. So, I created some additional methods to define all the queries needed for these operations. But, when I was defining the get and save methods themselves, I originally put them in the `MainViewModel`. However, I wasn't able to test these functions since they launched separate coroutines from the test dispatcher in the test files. I also noticed on the UI that the recent recipes were loading more slowly on launch compared to the other platforms. I'm not sure if this was just an emulator thing, but in any case, I added a fade animation to make its appearance more seamless.

Speaking of tests, I wanted to test the actual DB logic instead of mocking all the DAO methods. But, I couldn't initialize an in-memory database in the unit tests. Based on [Android's testing docs](https://developer.android.com/training/data-storage/room/testing-db#android) I had to make all the tests instrumented so I had access to a real application context. But at least I don't need to start a Compose test rule, so these tests should run faster than all the other instrumented tests.

Anyway, after a lot of troubleshooting & bothering Gemini, I decided to move all the DB logic to the `RecipeRepository`. This made it easier to test just the logic I needed when saving and fetching the recent recipes, without dealing with separate coroutine scopes or interfaces/abstract functions. I initially hesitated to have 4 layers to access the DB (MVVM + repository, compared to just MVVM on iOS and web), but it was more optimal this way due to how all the Android code is structured.