### PR TITLE
97 ask for in app review

### DIFF
--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -55,6 +55,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         // Check compatibility table before updating:
@@ -70,6 +71,7 @@ android {
 
 dependencies {
     val composeBomVersion = "2024.06.00"
+    val googlePlayVersion = "2.0.1"
     val lifecycleVersion = "2.8.3"
     val materialVersion = "1.6.8"
     val material3Version = "1.2.1"
@@ -105,6 +107,9 @@ dependencies {
     implementation("androidx.room:room-ktx:$roomVersion")
     annotationProcessor("androidx.room:room-compiler:$roomVersion")
     ksp("androidx.room:room-compiler:$roomVersion")
+    // Google Play
+    implementation("com.google.android.play:review:$googlePlayVersion")
+    implementation("com.google.android.play:review-ktx:$googlePlayVersion")
 
     testImplementation(platform("org.junit:junit-bom:$jupiterVersion"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/DataStoreService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/storage/DataStoreService.kt
@@ -3,6 +3,7 @@ package com.abhiek.ezrecipes.data.storage
 import android.content.Context
 import android.util.Log
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.abhiek.ezrecipes.data.models.Term
 import com.abhiek.ezrecipes.data.models.TermStore
@@ -24,6 +25,8 @@ class DataStoreService(context: Context) {
     companion object {
         private const val TAG = "DataStoreService"
         private val KEY_TERMS = stringPreferencesKey("terms")
+        private val KEY_RECIPES_VIEWED = intPreferencesKey("recipes_viewed")
+        private val KEY_LAST_VERSION_REVIEWED = intPreferencesKey("last_version_reviewed")
     }
 
     suspend fun getTerms(): List<Term>? {
@@ -63,6 +66,27 @@ class DataStoreService(context: Context) {
             val termStoreStr = gson.toJson(termStore)
             preferences[KEY_TERMS] = termStoreStr
             Log.i(TAG, "Saved terms to DataStore!")
+        }
+    }
+
+    suspend fun getRecipesViewed() = dataStore.data.map { preferences ->
+        preferences[KEY_RECIPES_VIEWED] ?: 0
+    }.first()
+
+    suspend fun incrementRecipesViewed() {
+        dataStore.edit { preferences ->
+            val recipesViewed = preferences[KEY_RECIPES_VIEWED] ?: 0
+            preferences[KEY_RECIPES_VIEWED] = recipesViewed + 1
+        }
+    }
+
+    suspend fun getLastVersionReviewed() = dataStore.data.map { preferences ->
+        preferences[KEY_LAST_VERSION_REVIEWED] ?: 0
+    }.first()
+
+    suspend fun setLastVersionReviewed(versionCode: Int) {
+        dataStore.edit { preferences ->
+            preferences[KEY_LAST_VERSION_REVIEWED] = versionCode
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -1,26 +1,38 @@
 package com.abhiek.ezrecipes.ui
 
+import android.app.Activity
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.abhiek.ezrecipes.BuildConfig
 import com.abhiek.ezrecipes.data.models.RecentRecipe
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.recipe.RecipeResult
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.models.RecipeError
+import com.abhiek.ezrecipes.data.storage.DataStoreService
+import com.abhiek.ezrecipes.utils.Constants
+import com.google.android.play.core.review.ReviewException
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.model.ReviewErrorCode
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 // Connects the View to the Repository
 class MainViewModel(
-    private val recipeRepository: RecipeRepository
+    private val recipeRepository: RecipeRepository,
+    private val dataStoreService: DataStoreService,
+    private val reviewManager: ReviewManager
 ): ViewModel() {
     // Only expose a read-only copy of the state to the View
     var job by mutableStateOf<Job?>(null)
         private set
     var recipeError by mutableStateOf<RecipeError?>(null)
+        private set
+    var canReview by mutableStateOf(false)
         private set
 
     var recipe by mutableStateOf<Recipe?>(null)
@@ -29,6 +41,11 @@ class MainViewModel(
     var isRecipeLoaded by mutableStateOf(false)
     var showRecipeAlert by mutableStateOf(false)
     var recentRecipes by mutableStateOf<List<RecentRecipe>>(listOf())
+
+    companion object {
+        const val TAG = "MainViewModel"
+        const val CURRENT_VERSION = BuildConfig.VERSION_CODE
+    }
 
     private fun updateRecipeProps(
         result: RecipeResult<Recipe>,
@@ -81,6 +98,44 @@ class MainViewModel(
     fun saveRecentRecipe(recipe: Recipe) {
         viewModelScope.launch {
             recipeRepository.saveRecentRecipe(recipe)
+        }
+    }
+
+    fun incrementRecipesViewed() {
+        viewModelScope.launch {
+            dataStoreService.incrementRecipesViewed()
+            val recipesViewed = dataStoreService.getRecipesViewed()
+            val lastVersionReviewed = dataStoreService.getLastVersionReviewed()
+
+            canReview = recipesViewed >= Constants.RECIPES_TO_PRESENT_REVIEW
+                    && CURRENT_VERSION > lastVersionReviewed
+        }
+    }
+
+    fun presentReview(activity: Activity) {
+        // Delay for two seconds to avoid interrupting the person using the app
+//        Thread.sleep(2000)
+        val request = reviewManager.requestReviewFlow()
+
+        request.addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val reviewInfo = task.result
+                Log.d(TAG, "Got the ReviewInfo object: $reviewInfo")
+                val flow = reviewManager.launchReviewFlow(activity, reviewInfo)
+
+                flow.addOnCompleteListener { a ->
+                    // The user may or may not have reviewed or was prompted to review
+                    Log.d(TAG, "Review flow complete! Result: ${a.result}")
+
+                    viewModelScope.launch {
+                        dataStoreService.setLastVersionReviewed(CURRENT_VERSION)
+                    }
+                }
+            } else {
+                @ReviewErrorCode
+                val reviewErrorCode = (task.exception as ReviewException).errorCode
+                Log.w(TAG, "Failed to request for a review: $reviewErrorCode")
+            }
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModel.kt
@@ -126,9 +126,9 @@ class MainViewModel(
                         delay(2000)
                         val flow = reviewManager.launchReviewFlow(activity, reviewInfo)
 
-                        flow.addOnCompleteListener { a ->
+                        flow.addOnCompleteListener {
                             // The user may or may not have reviewed or was prompted to review
-                            Log.d(TAG, "Review flow complete! Result: ${a.result}")
+                            Log.d(TAG, "Review flow complete!")
                             viewModelScope.launch {
                                 dataStoreService.setLastVersionReviewed(CURRENT_VERSION)
                             }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModelProvider
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.recipe.RecipeService
 import com.abhiek.ezrecipes.data.storage.AppDatabase
+import com.abhiek.ezrecipes.data.storage.DataStoreService
+import com.google.android.play.core.review.ReviewManagerFactory
 
 // Required to initialize a ViewModel with a non-empty constructor
 class MainViewModelFactory(private val context: Context): ViewModelProvider.Factory {
@@ -16,7 +18,9 @@ class MainViewModelFactory(private val context: Context): ViewModelProvider.Fact
                 recipeRepository = RecipeRepository(
                     recipeService = RecipeService.instance,
                     recentRecipeDao = AppDatabase.getInstance(context).recentRecipeDao()
-                )
+                ),
+                dataStoreService = DataStoreService(context),
+                reviewManager = ReviewManagerFactory.create(context)
             ) as T
         }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -55,10 +55,8 @@ fun Home(
     LaunchedEffect(Unit) {
         mainViewModel.fetchRecentRecipes()
 
-        // If the user viewed enough recipes, ask for a review
-        // Only ask once per app version to avoid intimidating the user and quickly reaching the quota
-        if (mainViewModel.canReview && activity != null) {
-            mainViewModel.presentReview(activity)
+        if (activity != null) {
+            mainViewModel.presentReviewIfQualified(activity)
         }
     }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -27,6 +27,7 @@ import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.storage.AppDatabase
+import com.abhiek.ezrecipes.data.storage.DataStoreService
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -36,6 +37,7 @@ import com.abhiek.ezrecipes.ui.search.RecipeCard
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
 import com.abhiek.ezrecipes.utils.getActivity
+import com.google.android.play.core.review.testing.FakeReviewManager
 import kotlinx.coroutines.delay
 
 @Composable
@@ -44,6 +46,7 @@ fun Home(
     onNavigateToRecipe: () -> Unit
 ) {
     val context = LocalContext.current
+    val activity = context.getActivity()
     val lifecycleOwner = LocalLifecycleOwner.current
 
     val defaultLoadingMessage = ""
@@ -51,6 +54,12 @@ fun Home(
 
     LaunchedEffect(Unit) {
         mainViewModel.fetchRecentRecipes()
+
+        // If the user viewed enough recipes, ask for a review
+        // Only ask once per app version to avoid intimidating the user and quickly reaching the quota
+        if (mainViewModel.canReview && activity != null) {
+            mainViewModel.presentReview(activity)
+        }
     }
 
     LaunchedEffect(mainViewModel.isLoading) {
@@ -237,7 +246,11 @@ private fun HomePreview(
     val recipeService = MockRecipeService
     val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
 
-    val viewModel = MainViewModel(RecipeRepository(recipeService, recentRecipeDao))
+    val viewModel = MainViewModel(
+        recipeRepository = RecipeRepository(recipeService, recentRecipeDao),
+        dataStoreService = DataStoreService(context),
+        reviewManager = FakeReviewManager(context)
+    )
     val (isLoading, showAlert, recentRecipes) = state
     viewModel.isLoading = isLoading
     viewModel.showRecipeAlert = showAlert // show the fallback alert in the preview

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -19,6 +19,7 @@ import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.storage.AppDatabase
+import com.abhiek.ezrecipes.data.storage.DataStoreService
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -26,12 +27,14 @@ import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.currentWindowSize
+import com.google.android.play.core.review.testing.FakeReviewManager
 
 @Composable
 fun Recipe(viewModel: MainViewModel, isWideScreen: Boolean, recipeIdString: String? = null) {
     LaunchedEffect(viewModel.recipe) {
         viewModel.recipe?.let { recipe ->
             viewModel.saveRecentRecipe(recipe)
+            viewModel.incrementRecipesViewed()
         }
     }
 
@@ -138,7 +141,11 @@ private fun RecipePreview() {
     val context = LocalContext.current
     val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
 
-    val viewModel = MainViewModel(RecipeRepository(MockRecipeService, recentRecipeDao))
+    val viewModel = MainViewModel(
+        recipeRepository = RecipeRepository(MockRecipeService, recentRecipeDao),
+        dataStoreService = DataStoreService(context),
+        reviewManager = FakeReviewManager(context)
+    )
     viewModel.getRandomRecipe()
     val windowSize = currentWindowSize()
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -24,6 +24,7 @@ import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.storage.AppDatabase
+import com.abhiek.ezrecipes.data.storage.DataStoreService
 import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -31,6 +32,7 @@ import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
+import com.google.android.play.core.review.testing.FakeReviewManager
 
 @Composable
 fun SearchResults(
@@ -126,7 +128,11 @@ private fun SearchResultsPreview(
     val recipeService = MockRecipeService
     val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
 
-    val recipeViewModel = MainViewModel(RecipeRepository(recipeService, recentRecipeDao))
+    val recipeViewModel = MainViewModel(
+        recipeRepository = RecipeRepository(recipeService, recentRecipeDao),
+        dataStoreService = DataStoreService(context),
+        reviewManager = FakeReviewManager(context)
+    )
     val searchViewModel = SearchViewModel(RecipeRepository((recipeService)))
     searchViewModel.recipes = recipes
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -21,6 +21,7 @@ object Constants {
 
     const val DATA_STORE_NAME = "data-store"
     const val MAX_RECENT_RECIPES = 10
+    const val RECIPES_TO_PRESENT_REVIEW = 5
 
     object Routes {
         // tabs = user-facing labels, routes = internal "pretend" URL paths

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
@@ -136,7 +136,9 @@ internal class MainViewModelTest {
     fun `don't present a review if not enough recipes are viewed`() = runTest {
         // Given a user that's viewed less than the required number of recipes
         coEvery { mockDataStoreService.getRecipesViewed() } returns 1
-        coEvery { mockDataStoreService.getLastVersionReviewed() } returns MainViewModel.CURRENT_VERSION - 1
+        coEvery {
+            mockDataStoreService.getLastVersionReviewed()
+        } returns MainViewModel.CURRENT_VERSION - 1
 
         // When presentReviewIfQualified() is called
         viewModel.presentReviewIfQualified(activity)
@@ -148,8 +150,12 @@ internal class MainViewModelTest {
     @Test
     fun `don't present a review on the same version`() = runTest {
         // Given a user that was already presented a review on the current app version
-        coEvery { mockDataStoreService.getRecipesViewed() } returns Constants.RECIPES_TO_PRESENT_REVIEW
-        coEvery { mockDataStoreService.getLastVersionReviewed() } returns MainViewModel.CURRENT_VERSION
+        coEvery {
+            mockDataStoreService.getRecipesViewed()
+        } returns Constants.RECIPES_TO_PRESENT_REVIEW
+        coEvery {
+            mockDataStoreService.getLastVersionReviewed()
+        } returns MainViewModel.CURRENT_VERSION
 
         // When presentReviewIfQualified() is called
         viewModel.presentReviewIfQualified(activity)
@@ -161,17 +167,24 @@ internal class MainViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `present a review if qualified`() = runTest {
-        // Given a user that's viewed enough recipes and hasn't already reviewed on the current app version
-        coEvery { mockDataStoreService.getRecipesViewed() } returns Constants.RECIPES_TO_PRESENT_REVIEW
-        coEvery { mockDataStoreService.getLastVersionReviewed() } returns MainViewModel.CURRENT_VERSION - 1
-        coEvery { mockDataStoreService.setLastVersionReviewed(any<Int>()) } returns Unit
+        // Given a user that's viewed enough recipes and hasn't reviewed on the current app version
+        coEvery {
+            mockDataStoreService.getRecipesViewed()
+        } returns Constants.RECIPES_TO_PRESENT_REVIEW
+        coEvery {
+            mockDataStoreService.getLastVersionReviewed()
+        } returns MainViewModel.CURRENT_VERSION - 1
+        coEvery {
+            mockDataStoreService.setLastVersionReviewed(any<Int>())
+        } returns Unit
 
+        // Mock all the completion listeners
         val requestFlowTask = mockk<Task<ReviewInfo>>()
         every { mockReviewManager.requestReviewFlow() } returns requestFlowTask
-        val requestListenerSlot = slot<OnCompleteListener<ReviewInfo>>()
         val reviewInfoMock = mockk<ReviewInfo>()
         every { requestFlowTask.isSuccessful } returns true
         every { requestFlowTask.result } returns reviewInfoMock
+        val requestListenerSlot = slot<OnCompleteListener<ReviewInfo>>()
         every { requestFlowTask.addOnCompleteListener(capture(requestListenerSlot)) } answers {
             requestListenerSlot.captured.onComplete(requestFlowTask)
             requestFlowTask

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/MainViewModelTest.kt
@@ -16,6 +16,8 @@ import com.google.android.play.core.review.testing.FakeReviewManager
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -156,6 +158,7 @@ internal class MainViewModelTest {
         verify(exactly = 0) { mockReviewManager.requestReviewFlow() }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `present a review if qualified`() = runTest {
         // Given a user that's viewed enough recipes and hasn't already reviewed on the current app version
@@ -184,10 +187,11 @@ internal class MainViewModelTest {
 
         // When presentReviewIfQualified() is called
         viewModel.presentReviewIfQualified(activity)
+        advanceUntilIdle() // run all coroutines and listeners
 
         // Then it should go through the review flow and save the last version reviewed
         verify { mockReviewManager.requestReviewFlow() }
-//        verify { mockReviewManager.launchReviewFlow(activity, any()) }
-//        coVerify { mockDataStoreService.setLastVersionReviewed(MainViewModel.CURRENT_VERSION) }
+        verify { mockReviewManager.launchReviewFlow(activity, any()) }
+        coVerify { mockDataStoreService.setLastVersionReviewed(MainViewModel.CURRENT_VERSION) }
     }
 }

--- a/EZRecipes/build.gradle.kts
+++ b/EZRecipes/build.gradle.kts
@@ -2,7 +2,7 @@
 plugins {
     val kotlinVersion = "1.9.22"
 
-    id("com.android.application") version "8.5.0" apply false
+    id("com.android.application") version "8.5.1" apply false
     id("org.jetbrains.kotlin.android") version kotlinVersion apply false
     // Version must match Kotlin: https://github.com/google/ksp/releases
     id("com.google.devtools.ksp") version "$kotlinVersion-1.0.17" apply false


### PR DESCRIPTION
Similar rules were applied from the iOS app to ask for a review once per version code after viewing 5 recipes. Also like the iOS app, I wait 2 seconds before showing the dialog so it doesn't appear abruptly after navigating back to the home screen. Google doesn't disclose what the quota is for showing a review, but I assume asking once per version should satisfy the quota, especially since we're not updating the app frequently. (There is technically a way to check if the review dialog was presented by looking for an [isNoOp flag](https://stackoverflow.com/a/77445461) in the ReviewInfo object.)

Once again, the toughest part was trying to test the code. The `presentReviewIfQualified` method is a little messy since I combined coroutines with the more traditional completion listeners of Tasks. Google offers a `FakeReviewManager` for unit testing, but since I still had to mock the context and activity, I had to mock the rest of the review methods as well, including the listeners. Ultimately, [this blog](https://cupsofcode.com/post/google_play_in-app_review_api_integration_mvi/) helped me set up all the mocks properly. Slots were the key to capturing the task results from each listener. Also, `advanceUntilIdle()` was needed to call all the coroutines inside the listeners.

The biggest difference between the iOS and Android implementations is that it's not possible to show the review dialog from a normal debug build ([docs](https://developer.android.com/guide/playcore/in-app-review/test)). The only way to test the full functionality is to deploy to an internal test track or use internal app sharing (which most closely resembles the iOS behavior since reviews can't be submitted this way). I plan on deploying to an internal test track anyway once the full build is ready, but I can try using internal app sharing to see if I can test this more quickly. If it works, I'll post an update.