### PR TITLE
Remove storage permissions for Screengrab

### DIFF
--- a/EZRecipes/app/src/main/AndroidManifest.xml
+++ b/EZRecipes/app/src/main/AndroidManifest.xml
@@ -4,15 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!-- Allows storing screenshots on external storage, where it can be accessed by ADB -->
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
-
     <!-- Allows changing locales -->
     <uses-permission
         android:name="android.permission.CHANGE_CONFIGURATION"


### PR DESCRIPTION
Screengrab should work just fine without these permissions. (It may warn, but I'm still able to retrieve all the screenshots.)