### PR TITLE
108 add insets to support android 15 edge to edge

### DIFF
--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -76,7 +76,8 @@ android {
 dependencies {
     val composeBomVersion = "2024.06.00"
     val googlePlayVersion = "2.0.1"
-    val lifecycleVersion = "2.8.3"
+    val lifecycleVersion = "2.8.4"
+    val activityVersion = "1.9.1"
     val materialVersion = "1.6.8"
     val material3Version = "1.2.1"
     val retrofitVersion = "2.11.0"
@@ -89,12 +90,13 @@ dependencies {
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion")
-    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.activity:activity-compose:$activityVersion")
+    implementation("androidx.activity:activity-ktx:$activityVersion")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material:material:$materialVersion")
     implementation("androidx.compose.material:material-icons-extended:$materialVersion")
-    //implementation("androidx.compose.material3:material3-android:$material3Version")
+    implementation("androidx.compose.material3:material3:$material3Version")
     implementation("androidx.compose.material3:material3-window-size-class:$material3Version")
     implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.datastore:datastore-preferences:1.1.1")

--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -94,7 +94,6 @@ dependencies {
     implementation("androidx.activity:activity-ktx:$activityVersion")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material:material:$materialVersion")
     implementation("androidx.compose.material:material-icons-extended:$materialVersion")
     implementation("androidx.compose.material3:material3:$material3Version")
     implementation("androidx.compose.material3:material3-window-size-class:$material3Version")

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
@@ -2,6 +2,7 @@ package com.abhiek.ezrecipes.ui
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -10,6 +11,10 @@ import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 
 class MainActivity : ComponentActivity() {
+    companion object {
+        private const val TAG = "MainActivity"
+    }
+
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -39,7 +44,7 @@ class MainActivity : ComponentActivity() {
         if (appLinkAction == Intent.ACTION_VIEW) {
             appLinkData?.lastPathSegment?.also { recipeId ->
                 // The navigation graph will take care of the deep link ;)
-                println("recipe ID = $recipeId")
+                Log.d(TAG, "recipe ID = $recipeId")
             }
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -12,6 +13,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainLayout.kt
@@ -1,28 +1,16 @@
 package com.abhiek.ezrecipes.ui
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.*
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.navigation.compose.rememberNavController
-import com.abhiek.ezrecipes.ui.navbar.*
+import com.abhiek.ezrecipes.ui.navbar.NavigationDrawer
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.currentWindowSize
-import com.abhiek.ezrecipes.utils.toPx
 
 @Composable
 fun MainLayout(
@@ -30,65 +18,18 @@ fun MainLayout(
 ) {
     // Remember functions can only be called in a composable, not an activity
     val scope = rememberCoroutineScope()
-    val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
     // The navigation controller shouldn't be recreated in other composables
     val navController = rememberNavController()
-    val drawerWidth = 300
-
-    LaunchedEffect(widthSizeClass) {
-        // Close the navigation drawer if the screen is too small
-        if (widthSizeClass != WindowWidthSizeClass.Expanded && scaffoldState.drawerState.isOpen) {
-            scaffoldState.drawerState.close()
-        }
-    }
 
     // Material Design layout guidelines:
     // https://developer.android.com/guide/topics/large-screens/navigation-for-responsive-uis#responsive_ui_navigation
     EZRecipesTheme {
-        // Great resource for setting up the navigation drawer: https://stackoverflow.com/a/73295465
-        Scaffold(
-            scaffoldState = scaffoldState,
-            topBar = {
-                TopBar(scope, scaffoldState, navController, widthSizeClass)
-            },
-            // Show the navigation bar on small screens
-            bottomBar = {
-                if (widthSizeClass == WindowWidthSizeClass.Compact) {
-                    BottomBar(navController)
-                }
-            },
-            // Show the navigation drawer on large screens
-            drawerContent = if (widthSizeClass == WindowWidthSizeClass.Expanded) {
-                { NavigationDrawer(scope, scaffoldState, navController, drawerWidth) }
-            } else null,
-            // Limit the width of the navigation drawer so there isn't much whitespace
-            drawerShape = object : Shape {
-                override fun createOutline(
-                    size: Size,
-                    layoutDirection: LayoutDirection,
-                    density: Density
-                ) = Outline.Rectangle(
-                    Rect(left = 0f, top = 0f, right = drawerWidth.toPx, bottom = size.height)
-                )
-            },
-            // Content padding parameter is required: https://stackoverflow.com/a/72085218
-            content = { padding ->
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.padding(padding),
-                    color = MaterialTheme.colors.background
-                ) {
-                    Row {
-                        // Show the navigation rail on medium screens
-                        if (widthSizeClass == WindowWidthSizeClass.Medium) {
-                            NavRail(navController)
-                        }
-
-                        NavigationGraph(navController, widthSizeClass)
-                    }
-                }
-            }
-        )
+        // Show the navigation drawer on large screens
+        if (widthSizeClass == WindowWidthSizeClass.Expanded) {
+            NavigationDrawer(scope, navController, widthSizeClass)
+        } else {
+            MainScaffold(scope, navController, widthSizeClass)
+        }
     }
 }
 
@@ -100,8 +41,5 @@ fun MainLayout(
 private fun MainLayoutPreview() {
     // Use the actual size of the device to show accurate previews
     val windowSize = currentWindowSize()
-
-    EZRecipesTheme {
-        MainLayout(windowSize.widthSizeClass)
-    }
+    MainLayout(windowSize.widthSizeClass)
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainScaffold.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainScaffold.kt
@@ -1,0 +1,75 @@
+package com.abhiek.ezrecipes.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.*
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.abhiek.ezrecipes.ui.navbar.*
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.currentWindowSize
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+fun MainScaffold(
+    scope: CoroutineScope,
+    navController: NavHostController,
+    widthSizeClass: WindowWidthSizeClass
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopBar(scope, navController, widthSizeClass)
+        },
+        // Show the navigation bar on small screens
+        bottomBar = {
+            if (widthSizeClass == WindowWidthSizeClass.Compact) {
+                BottomBar(navController)
+            }
+        },
+        // Content padding parameter is required: https://stackoverflow.com/a/72085218
+        content = { padding ->
+            // A surface container using the 'background' color from the theme
+            Surface(
+                modifier = Modifier.padding(padding),
+                color = MaterialTheme.colorScheme.background
+            ) {
+                Row {
+                    // Show the navigation rail on medium screens
+                    if (widthSizeClass == WindowWidthSizeClass.Medium) {
+                        NavRail(navController)
+                    }
+
+                    NavigationGraph(navController, widthSizeClass)
+                }
+            }
+        }
+    )
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun MainScaffoldPreview() {
+    val scope = rememberCoroutineScope()
+    // Use the actual size of the device to show accurate previews
+    val windowSize = currentWindowSize()
+    val navController = rememberNavController()
+
+    EZRecipesTheme {
+        MainScaffold(scope, navController, windowSize.widthSizeClass)
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainScaffold.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainScaffold.kt
@@ -23,14 +23,15 @@ import kotlinx.coroutines.CoroutineScope
 fun MainScaffold(
     scope: CoroutineScope,
     navController: NavHostController,
-    widthSizeClass: WindowWidthSizeClass
+    widthSizeClass: WindowWidthSizeClass,
+    drawerState: DrawerState? = null
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            TopBar(scope, navController, widthSizeClass)
+            TopBar(scope, navController, widthSizeClass, drawerState)
         },
         // Show the navigation bar on small screens
         bottomBar = {
@@ -68,8 +69,9 @@ private fun MainScaffoldPreview() {
     // Use the actual size of the device to show accurate previews
     val windowSize = currentWindowSize()
     val navController = rememberNavController()
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
 
     EZRecipesTheme {
-        MainScaffold(scope, navController, windowSize.widthSizeClass)
+        MainScaffold(scope, navController, windowSize.widthSizeClass, drawerState)
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/glossary/Glossary.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/glossary/Glossary.kt
@@ -5,10 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Divider
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,7 +49,7 @@ fun Glossary(terms: List<Term>) {
                 )
 
                 if (index < terms.lastIndex) {
-                    Divider()
+                    HorizontalDivider()
                 }
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -109,7 +109,7 @@ fun Home(
         Button(
             onClick = { mainViewModel.getRandomRecipe(fromHome = true) },
             colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.secondary
+                containerColor = MaterialTheme.colorScheme.tertiary
             ),
             enabled = !mainViewModel.isLoading, // prevent button spam
             modifier = Modifier.padding(top = 32.dp)
@@ -159,25 +159,6 @@ fun Home(
                         )
                     }
                 },
-//                buttons = {
-//                    // Position the button at the bottom right of the alert
-//                    Row(
-//                        modifier = Modifier
-//                            .padding(8.dp)
-//                            .fillMaxWidth(),
-//                        horizontalArrangement = Arrangement.End
-//                    ) {
-//                        Button(
-//                            onClick = {
-//                                mainViewModel.showRecipeAlert = false
-//                            }
-//                        ) {
-//                            Text(
-//                                text = stringResource(R.string.ok_button)
-//                            )
-//                        }
-//                    }
-//                },
                 modifier = Modifier.padding(horizontal = 8.dp)
             )
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -109,7 +109,7 @@ fun Home(
         Button(
             onClick = { mainViewModel.getRandomRecipe(fromHome = true) },
             colors = ButtonDefaults.buttonColors(
-                backgroundColor = MaterialTheme.colors.secondary
+                containerColor = MaterialTheme.colorScheme.secondary
             ),
             enabled = !mainViewModel.isLoading, // prevent button spam
             modifier = Modifier.padding(top = 32.dp)
@@ -148,25 +148,36 @@ fun Home(
                            stringResource(R.string.unknown_error)
                        )
                 },
-                buttons = {
-                    // Position the button at the bottom right of the alert
-                    Row(
-                        modifier = Modifier
-                            .padding(8.dp)
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        Button(
-                            onClick = {
-                                mainViewModel.showRecipeAlert = false
-                            }
-                        ) {
-                            Text(
-                                text = stringResource(R.string.ok_button)
-                            )
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            mainViewModel.showRecipeAlert = false
                         }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.ok_button)
+                        )
                     }
                 },
+//                buttons = {
+//                    // Position the button at the bottom right of the alert
+//                    Row(
+//                        modifier = Modifier
+//                            .padding(8.dp)
+//                            .fillMaxWidth(),
+//                        horizontalArrangement = Arrangement.End
+//                    ) {
+//                        Button(
+//                            onClick = {
+//                                mainViewModel.showRecipeAlert = false
+//                            }
+//                        ) {
+//                            Text(
+//                                text = stringResource(R.string.ok_button)
+//                            )
+//                        }
+//                    }
+//                },
                 modifier = Modifier.padding(horizontal = 8.dp)
             )
         }
@@ -185,9 +196,9 @@ fun Home(
             ) {
                 Text(
                     text = stringResource(R.string.recently_viewed),
-                    style = MaterialTheme.typography.h4
+                    style = MaterialTheme.typography.headlineMedium
                 )
-                Divider()
+                HorizontalDivider()
 
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -109,7 +109,8 @@ fun Home(
         Button(
             onClick = { mainViewModel.getRandomRecipe(fromHome = true) },
             colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.tertiary
+                containerColor = MaterialTheme.colorScheme.tertiary,
+                contentColor = MaterialTheme.colorScheme.onTertiary
             ),
             enabled = !mainViewModel.isLoading, // prevent button spam
             modifier = Modifier.padding(top = 32.dp)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/BottomBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/BottomBar.kt
@@ -1,12 +1,12 @@
 package com.abhiek.ezrecipes.ui.navbar
 
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
@@ -16,15 +16,15 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun BottomBar(navController: NavController) {
+fun BottomBar(navController: NavHostController) {
     val bottomNavBarItems = listOf(Tab.Home, Tab.Search, Tab.Glossary)
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
 
-    BottomNavigation {
+    NavigationBar {
         bottomNavBarItems.forEach { item ->
-            BottomNavigationItem(
+            NavigationBarItem(
                 icon = { Icon(item.icon, contentDescription = null) },
                 label = { Text(stringResource(item.resourceId)) },
                 // Keep the tab selected as long as it matches one of the parent routes

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/BottomBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/BottomBar.kt
@@ -22,13 +22,20 @@ fun BottomBar(navController: NavHostController) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
 
-    NavigationBar {
+    NavigationBar(
+        containerColor = MaterialTheme.colorScheme.primary
+    ) {
         bottomNavBarItems.forEach { item ->
             NavigationBarItem(
                 icon = { Icon(item.icon, contentDescription = null) },
                 label = { Text(stringResource(item.resourceId)) },
                 // Keep the tab selected as long as it matches one of the parent routes
                 selected = currentDestination?.hierarchy?.any { it.route == item.route } == true,
+                colors = NavigationBarItemDefaults.colors().copy(
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimary,
+                    unselectedIconColor = MaterialTheme.colorScheme.onPrimary,
+                    unselectedTextColor = MaterialTheme.colorScheme.onPrimary
+                ),
                 onClick = {
                     navController.navigate(item.route) {
                         // Pop up to the start destination of the graph to

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
@@ -3,9 +3,9 @@ package com.abhiek.ezrecipes.ui.navbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,7 +22,7 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 @Composable
 fun DrawerListItem(item: Tab, selected: Boolean, onItemClick: () -> Unit) {
     // Highlight the selected drawer item
-    val backgroundColor = if (selected) MaterialTheme.colors.secondary else Color.Transparent
+    val backgroundColor = if (selected) MaterialTheme.colorScheme.secondary else Color.Transparent
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -40,17 +40,17 @@ fun DrawerListItem(item: Tab, selected: Boolean, onItemClick: () -> Unit) {
                 .height(32.dp)
                 .width(32.dp),
             // In dark mode, black contrasts with yellow better than white
-            tint = if (selected) Color.Black else MaterialTheme.colors.onBackground
+            tint = if (selected) Color.Black else MaterialTheme.colorScheme.onBackground
         )
         Spacer(
             modifier = Modifier.width(16.dp)
         )
         Text(
             text = stringResource(item.resourceId),
-            style = MaterialTheme.typography.subtitle1.copy(
+            style = MaterialTheme.typography.titleMedium.copy(
                 fontSize = 18.sp
             ),
-            color = if (selected) Color.Black else MaterialTheme.colors.onBackground,
+            color = if (selected) Color.Black else MaterialTheme.colorScheme.onBackground,
             modifier = Modifier.clickable(onClick = onItemClick)
         )
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
@@ -22,7 +22,7 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 @Composable
 fun DrawerListItem(item: Tab, selected: Boolean, onItemClick: () -> Unit) {
     // Highlight the selected drawer item
-    val backgroundColor = if (selected) MaterialTheme.colorScheme.secondary else Color.Transparent
+    val backgroundColor = if (selected) MaterialTheme.colorScheme.tertiary else Color.Transparent
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -66,6 +66,7 @@ fun DrawerListItemPreview() {
         Column {
             DrawerListItem(item = Tab.Home, selected = true) {}
             DrawerListItem(item = Tab.Search, selected = false) {}
+            DrawerListItem(item = Tab.Glossary, selected = false) {}
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavRail.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavRail.kt
@@ -1,11 +1,11 @@
 package com.abhiek.ezrecipes.ui.navbar
 
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
@@ -15,7 +15,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun NavRail(navController: NavController) {
+fun NavRail(navController: NavHostController) {
     val railItems = listOf(Tab.Home, Tab.Search, Tab.Glossary)
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -2,38 +2,50 @@ package com.abhiek.ezrecipes.ui.navbar
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.material3.*
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.ui.MainScaffold
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.currentWindowSize
+import com.abhiek.ezrecipes.utils.toPx
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @Composable
 fun NavigationDrawer(
     scope: CoroutineScope,
-    scaffoldState: ScaffoldState,
-    navController: NavController,
-    width: Int
+    navController: NavHostController,
+    widthSizeClass: WindowWidthSizeClass,
+    width: Int = 300
 ) {
     /* Using sealedSubclasses requires reflection, which will make the app slower,
      * so list each drawer item manually
      */
     val drawerItems = listOf(Tab.Home, Tab.Search, Tab.Glossary)
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -42,40 +54,70 @@ fun NavigationDrawer(
     val logoWidth = 100
     val logoHorizontalPadding = (width - logoWidth) / 2
 
-    Column {
-        // Show the app logo at the top
-        Image(
-            painter = painterResource(R.mipmap.ic_launcher_foreground),
-            contentDescription = stringResource(R.string.app_logo_alt),
-            modifier = Modifier
-                .height(logoWidth.dp)
-                .padding(horizontal = logoHorizontalPadding.dp, vertical = 8.dp)
-        )
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(8.dp)
-        )
-        // Loop through all the subclasses of the sealed Tab class
-        drawerItems.forEach { item ->
-            DrawerListItem(
-                item = item,
-                // Highlight the drawer item corresponding to the current route on screen
-                selected = currentRoute == item.route,
-                onItemClick = {
-                    navController.navigate(item.route) {
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                    scope.launch {
-                        scaffoldState.drawerState.close()
+    LaunchedEffect(widthSizeClass) {
+        // Close the navigation drawer if the screen is too small
+        if (widthSizeClass != WindowWidthSizeClass.Expanded && drawerState.isOpen) {
+            drawerState.close()
+        }
+    }
+
+    // Great resource for setting up the navigation drawer: https://stackoverflow.com/a/73295465
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        // ModalNavigationDrawer.drawerContent.ModalDrawerSheet.content = UI inside drawer
+        // ModalNavigationDrawer.content = UI outside drawer
+        drawerContent = {
+            ModalDrawerSheet(
+                // Limit the width of the navigation drawer so there isn't much whitespace
+                drawerShape = object : Shape {
+                    override fun createOutline(
+                        size: Size,
+                        layoutDirection: LayoutDirection,
+                        density: Density
+                    ) = Outline.Rectangle(
+                        Rect(left = 0f, top = 0f, right = width.toPx, bottom = size.height)
+                    )
+                },
+            ) {
+                Column {
+                    // Show the app logo at the top
+                    Image(
+                        painter = painterResource(R.mipmap.ic_launcher_foreground),
+                        contentDescription = stringResource(R.string.app_logo_alt),
+                        modifier = Modifier
+                            .height(logoWidth.dp)
+                            .padding(horizontal = logoHorizontalPadding.dp, vertical = 8.dp)
+                    )
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(8.dp)
+                    )
+                    // Loop through all the subclasses of the sealed Tab class
+                    drawerItems.forEach { item ->
+                        DrawerListItem(
+                            item = item,
+                            // Highlight the drawer item corresponding to the current route on screen
+                            selected = currentRoute == item.route,
+                            onItemClick = {
+                                navController.navigate(item.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                                scope.launch {
+                                    drawerState.close()
+                                }
+                            }
+                        )
                     }
                 }
-            )
+            }
         }
+    ) {
+        MainScaffold(scope, navController, widthSizeClass)
     }
 }
 
@@ -86,12 +128,12 @@ fun NavigationDrawer(
 @Composable
 private fun NavigationDrawerPreview() {
     val scope = rememberCoroutineScope()
-    val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
     val navController = rememberNavController()
+    val windowSize = currentWindowSize()
 
     EZRecipesTheme {
         Surface {
-            NavigationDrawer(scope, scaffoldState, navController, 300)
+            NavigationDrawer(scope, navController, windowSize.widthSizeClass)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -39,13 +41,14 @@ fun NavigationDrawer(
     scope: CoroutineScope,
     navController: NavHostController,
     widthSizeClass: WindowWidthSizeClass,
-    width: Int = 300
+    width: Int = 300,
+    initialDrawerValue: DrawerValue = DrawerValue.Closed
 ) {
     /* Using sealedSubclasses requires reflection, which will make the app slower,
      * so list each drawer item manually
      */
     val drawerItems = listOf(Tab.Home, Tab.Search, Tab.Glossary)
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
+    val drawerState = rememberDrawerState(initialDrawerValue)
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
@@ -117,8 +120,12 @@ fun NavigationDrawer(
             }
         }
     ) {
-        MainScaffold(scope, navController, widthSizeClass)
+        MainScaffold(scope, navController, widthSizeClass, drawerState)
     }
+}
+
+private class NavigationDrawerPreviewParameterProvider: PreviewParameterProvider<DrawerValue> {
+    override val values = sequenceOf(DrawerValue.Closed, DrawerValue.Open)
 }
 
 @DevicePreviews
@@ -126,14 +133,21 @@ fun NavigationDrawer(
 @FontPreviews
 @OrientationPreviews
 @Composable
-private fun NavigationDrawerPreview() {
+private fun NavigationDrawerPreview(
+    @PreviewParameter(NavigationDrawerPreviewParameterProvider::class) drawerValue: DrawerValue
+) {
     val scope = rememberCoroutineScope()
     val navController = rememberNavController()
     val windowSize = currentWindowSize()
 
     EZRecipesTheme {
         Surface {
-            NavigationDrawer(scope, navController, windowSize.widthSizeClass)
+            NavigationDrawer(
+                scope,
+                navController,
+                windowSize.widthSizeClass,
+                initialDrawerValue = drawerValue
+            )
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -2,7 +2,7 @@ package com.abhiek.ezrecipes.ui.navbar
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material.Surface
+import androidx.compose.material3.Surface
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -92,7 +92,10 @@ fun TopBar(
             }
         },
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.primary
+            containerColor = MaterialTheme.colorScheme.primary,
+            navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+            titleContentColor = MaterialTheme.colorScheme.onPrimary,
+            actionIconContentColor = MaterialTheme.colorScheme.onPrimary
         )
     )
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -2,17 +2,17 @@ package com.abhiek.ezrecipes.ui.navbar
 
 import android.content.ClipDescription
 import android.content.Intent
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.R
@@ -26,12 +26,13 @@ import com.abhiek.ezrecipes.utils.currentWindowSize
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopBar(
     scope: CoroutineScope,
-    scaffoldState: ScaffoldState,
-    navController: NavController,
-    widthSizeClass: WindowWidthSizeClass
+    navController: NavHostController,
+    widthSizeClass: WindowWidthSizeClass,
+    drawerState: DrawerState? = null
 ) {
     var isFavorite by remember { mutableStateOf(false) }
     // Get a context variable like in activities
@@ -62,7 +63,7 @@ fun TopBar(
                 IconButton(
                     onClick = {
                         scope.launch {
-                            scaffoldState.drawerState.open()
+                            drawerState?.open()
                         }
                     }
                 ) {
@@ -90,7 +91,9 @@ fun TopBar(
                 }
             }
         },
-        backgroundColor = MaterialTheme.colors.primary
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primary
+        )
     )
 }
 
@@ -101,11 +104,11 @@ fun TopBar(
 @Composable
 fun TopBarPreview() {
     val scope = rememberCoroutineScope()
-    val scaffoldState = rememberScaffoldState(rememberDrawerState(DrawerValue.Closed))
     val navController = rememberNavController()
     val windowSize = currentWindowSize()
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
 
     EZRecipesTheme {
-        TopBar(scope, scaffoldState, navController, windowSize.widthSizeClass)
+        TopBar(scope, navController, windowSize.widthSizeClass, drawerState)
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/IngredientsList.kt
@@ -1,7 +1,7 @@
 package com.abhiek.ezrecipes.ui.recipe
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -21,18 +21,17 @@ import com.abhiek.ezrecipes.utils.capitalizeWords
 
 @Composable
 fun IngredientsList(ingredients: List<Ingredient>) {
-    Card(
+    ElevatedCard(
         modifier = Modifier
             .width(400.dp)
-            .padding(16.dp),
-        elevation = 10.dp
+            .padding(16.dp)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             Text(
                 text = stringResource(R.string.ingredients),
-                style = MaterialTheme.typography.h5.copy(
+                style = MaterialTheme.typography.headlineSmall.copy(
                     fontWeight = FontWeight.Bold,
                     textAlign = TextAlign.Center
                 ),
@@ -41,7 +40,7 @@ fun IngredientsList(ingredients: List<Ingredient>) {
                     .padding(top = 8.dp)
             )
 
-            Divider()
+            HorizontalDivider()
 
             // Ingredients list
             Column(
@@ -57,13 +56,13 @@ fun IngredientsList(ingredients: List<Ingredient>) {
                     ) {
                         Text(
                             text = "${ingredient.amount} ${ingredient.unit}",
-                            style = MaterialTheme.typography.body1.copy(
+                            style = MaterialTheme.typography.bodyLarge.copy(
                                 fontSize = 18.sp
                             )
                         )
                         Text(
                             text = ingredient.name.capitalizeWords(),
-                            style = MaterialTheme.typography.body1.copy(
+                            style = MaterialTheme.typography.bodyLarge.copy(
                                 fontSize = 18.sp,
                                 textAlign = TextAlign.End
                             )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/InstructionsList.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/InstructionsList.kt
@@ -6,9 +6,9 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,7 +35,7 @@ fun InstructionsList(instructions: List<Instruction>) {
     ) {
         Text(
             text = stringResource(R.string.steps),
-            style = MaterialTheme.typography.h6.copy(
+            style = MaterialTheme.typography.titleLarge.copy(
                 fontSize = 22.sp,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center
@@ -48,7 +48,7 @@ fun InstructionsList(instructions: List<Instruction>) {
             if (instruction.name.isNotEmpty()) {
                 Text(
                     text = instruction.name,
-                    style = MaterialTheme.typography.subtitle1.copy(
+                    style = MaterialTheme.typography.titleMedium.copy(
                         fontSize = 18.sp,
                         textAlign = TextAlign.Center
                     ),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/NutritionLabel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/NutritionLabel.kt
@@ -1,7 +1,7 @@
 package com.abhiek.ezrecipes.ui.recipe
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,11 +28,10 @@ fun NutritionLabel(recipe: Recipe) {
     // Nutrients that should be bolded on the nutrition label
     val nutrientHeadings = listOf("Calories", "Fat", "Carbohydrates", "Protein")
 
-    Card(
+    ElevatedCard(
         modifier = Modifier
             .width(300.dp)
-            .padding(16.dp),
-        elevation = 10.dp
+            .padding(16.dp)
     ) {
         Column(
             modifier = Modifier.padding(8.dp)
@@ -45,21 +44,21 @@ fun NutritionLabel(recipe: Recipe) {
             ) {
                 Text(
                     text = stringResource(R.string.nutrition_facts),
-                    style = MaterialTheme.typography.h5.copy(
+                    style = MaterialTheme.typography.headlineSmall.copy(
                         fontWeight = FontWeight.Bold
                     )
                 )
                 Text(
                     text = stringResource(R.string.health_score, recipe.healthScore),
-                    style = MaterialTheme.typography.subtitle1
+                    style = MaterialTheme.typography.titleMedium
                 )
                 Text(
                     text = context.resources.getQuantityString(R.plurals.servings, recipe.servings, recipe.servings),
-                    style = MaterialTheme.typography.subtitle1
+                    style = MaterialTheme.typography.titleMedium
                 )
             }
 
-            Divider(
+            HorizontalDivider(
                 modifier = Modifier.padding(vertical = 8.dp)
             )
 
@@ -83,14 +82,14 @@ fun NutritionLabel(recipe: Recipe) {
                     ) {
                         Text(
                             text = nutrient.name,
-                            style = MaterialTheme.typography.body1.copy(
+                            style = MaterialTheme.typography.bodyLarge.copy(
                                 fontSize = 18.sp,
                                 fontWeight = if (isBold) FontWeight.Bold else FontWeight.Normal
                             )
                         )
                         Text(
                             text = "$formattedAmount ${nutrient.unit}",
-                            style = MaterialTheme.typography.body1.copy(
+                            style = MaterialTheme.typography.bodyLarge.copy(
                                 fontSize = 18.sp,
                                 fontWeight = if (isBold) FontWeight.Bold else FontWeight.Normal,
                                 textAlign = TextAlign.End

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/Recipe.kt
@@ -3,10 +3,7 @@ package com.abhiek.ezrecipes.ui.recipe
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Divider
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.*
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -125,7 +122,7 @@ fun Recipe(viewModel: MainViewModel, isWideScreen: Boolean, recipeIdString: Stri
 
             InstructionsList(instructions = recipe.instructions)
 
-            Divider()
+            HorizontalDivider()
 
             RecipeFooter()
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeFooter.kt
@@ -2,9 +2,9 @@ package com.abhiek.ezrecipes.ui.recipe
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -21,7 +21,7 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 fun RecipeFooter() {
     Text(
         text = stringResource(R.string.attribution),
-        style = MaterialTheme.typography.caption.copy(
+        style = MaterialTheme.typography.bodySmall.copy(
             textAlign = TextAlign.Center
         ),
         modifier = Modifier

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -165,7 +165,9 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.error
                     ),
-                    onClick = { println("Nice! Hope it was tasty!") }
+                    onClick = { println("Nice! Hope it was tasty!") },
+                    // Reduce padding to make the icon take up more space
+                    contentPadding = PaddingValues(8.dp)
                 ) {
                     Icon(Icons.Default.Restaurant, stringResource(R.string.made_button))
                 }
@@ -186,9 +188,11 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     modifier = Modifier.size(50.dp),
                     shape = CircleShape,
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.tertiary
+                        containerColor = MaterialTheme.colorScheme.tertiary,
+                        contentColor = MaterialTheme.colorScheme.onTertiary
                     ),
                     onClick = { onClickFindRecipe() },
+                    contentPadding = PaddingValues(8.dp),
                     enabled = !isLoading
                 ) {
                     Icon(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -32,7 +32,6 @@ import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
-import com.abhiek.ezrecipes.ui.theme.Blue300
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.boldAnnotatedString
 import com.abhiek.ezrecipes.utils.contentEquals
@@ -53,7 +52,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
         // Apply a blue link style to the section after the copyright symbol
         addStyle(
             style = SpanStyle(
-                color = Blue300,
+                color = MaterialTheme.colorScheme.primary,
                 textDecoration = TextDecoration.Underline
             ),
             start = startIndex,
@@ -169,7 +168,11 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     // Reduce padding to make the icon take up more space
                     contentPadding = PaddingValues(8.dp)
                 ) {
-                    Icon(Icons.Default.Restaurant, stringResource(R.string.made_button))
+                    Icon(
+                        Icons.Default.Restaurant,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onError
+                    )
                 }
                 Text(
                     text = stringResource(R.string.made_button),
@@ -197,7 +200,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                 ) {
                     Icon(
                         Icons.AutoMirrored.Filled.ReceiptLong,
-                        stringResource(R.string.show_recipe_button)
+                        contentDescription = null
                     )
                 }
                 Text(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -186,7 +186,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     modifier = Modifier.size(50.dp),
                     shape = CircleShape,
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.secondary
+                        containerColor = MaterialTheme.colorScheme.tertiary
                     ),
                     onClick = { onClickFindRecipe() },
                     enabled = !isLoading

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -3,10 +3,10 @@ package com.abhiek.ezrecipes.ui.recipe
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.ClickableText
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ReceiptLong
 import androidx.compose.material.icons.filled.Restaurant
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -87,8 +87,8 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
 
         ClickableText(
             text = annotatedLinkString,
-            style = MaterialTheme.typography.caption.copy(
-                color = MaterialTheme.colors.onBackground
+            style = MaterialTheme.typography.bodySmall.copy(
+                color = MaterialTheme.colorScheme.onBackground
             ),
             modifier = Modifier.padding(horizontal = 8.dp)
         ) { offset ->
@@ -118,7 +118,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                 text = context.resources.getQuantityString(R.plurals.recipe_time, recipe.time, recipe.time),
                 endIndex = 5 // "Time:".length = 5
             ),
-            style = MaterialTheme.typography.h6,
+            style = MaterialTheme.typography.titleLarge,
             modifier = Modifier.padding(vertical = 8.dp)
         )
 
@@ -163,7 +163,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     modifier = Modifier.size(50.dp), // avoid the oval shape
                     shape = CircleShape,
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = MaterialTheme.colors.error
+                        containerColor = MaterialTheme.colorScheme.error
                     ),
                     onClick = { println("Nice! Hope it was tasty!") }
                 ) {
@@ -171,7 +171,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                 }
                 Text(
                     text = stringResource(R.string.made_button),
-                    style = MaterialTheme.typography.button.copy(
+                    style = MaterialTheme.typography.labelLarge.copy(
                         fontSize = 16.sp,
                         textAlign = TextAlign.Center
                     )
@@ -186,7 +186,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     modifier = Modifier.size(50.dp),
                     shape = CircleShape,
                     colors = ButtonDefaults.buttonColors(
-                        backgroundColor = MaterialTheme.colors.secondary
+                        containerColor = MaterialTheme.colorScheme.secondary
                     ),
                     onClick = { onClickFindRecipe() },
                     enabled = !isLoading
@@ -198,7 +198,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                 }
                 Text(
                     text = stringResource(R.string.show_recipe_button),
-                    style = MaterialTheme.typography.button.copy(
+                    style = MaterialTheme.typography.labelLarge.copy(
                         fontSize = 16.sp,
                         textAlign = TextAlign.Center
                     )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -169,8 +169,8 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     contentPadding = PaddingValues(8.dp)
                 ) {
                     Icon(
-                        Icons.Default.Restaurant,
-                        contentDescription = null,
+                        imageVector = Icons.Default.Restaurant,
+                        contentDescription = stringResource(R.string.made_button),
                         tint = MaterialTheme.colorScheme.onError
                     )
                 }
@@ -199,8 +199,8 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     enabled = !isLoading
                 ) {
                     Icon(
-                        Icons.AutoMirrored.Filled.ReceiptLong,
-                        contentDescription = null
+                        imageVector = Icons.AutoMirrored.Filled.ReceiptLong,
+                        contentDescription = stringResource(R.string.show_recipe_button)
                     )
                 }
                 Text(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipePills.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipePills.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,37 +50,37 @@ fun RecipePills(
         if (isVegetarian) {
             Pill(
                 text = stringResource(R.string.vegetarian_label),
-                backgroundColor = MaterialTheme.colors.primary
+                backgroundColor = MaterialTheme.colorScheme.primary
             )
         }
         if (isVegan) {
             Pill(
                 text = stringResource(R.string.vegan_label),
-                backgroundColor = MaterialTheme.colors.primary
+                backgroundColor = MaterialTheme.colorScheme.primary
             )
         }
         if (isGlutenFree) {
             Pill(
                 text = stringResource(R.string.gluten_free_label),
-                backgroundColor = MaterialTheme.colors.primary
+                backgroundColor = MaterialTheme.colorScheme.primary
             )
         }
         if (isHealthy) {
             Pill(
                 text = stringResource(R.string.healthy_label),
-                backgroundColor = MaterialTheme.colors.primary
+                backgroundColor = MaterialTheme.colorScheme.primary
             )
         }
         if (isCheap) {
             Pill(
                 text = stringResource(R.string.cheap_label),
-                backgroundColor = MaterialTheme.colors.primary
+                backgroundColor = MaterialTheme.colorScheme.primary
             )
         }
         if (isSustainable) {
             Pill(
                 text = stringResource(R.string.sustainable_label),
-                backgroundColor = MaterialTheme.colors.primary
+                backgroundColor = MaterialTheme.colorScheme.primary
             )
         }
     }
@@ -98,7 +98,7 @@ private fun Pill(text: String, backgroundColor: Color, textColor: Color = Color.
         Text(
             text = text,
             color = textColor,
-            style = MaterialTheme.typography.caption,
+            style = MaterialTheme.typography.bodySmall,
             modifier = Modifier
                 .padding(horizontal = 8.dp, vertical = 4.dp)
         )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeTitle.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeTitle.kt
@@ -1,9 +1,9 @@
 package com.abhiek.ezrecipes.ui.recipe
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,7 +36,7 @@ fun RecipeTitle(recipe: Recipe) {
         // Recipe name and source link
         Text(
             text = recipe.name.capitalizeWords(),
-            style = MaterialTheme.typography.h5.copy(
+            style = MaterialTheme.typography.headlineSmall.copy(
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center
             ),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/StepCard.kt
@@ -3,7 +3,7 @@ package com.abhiek.ezrecipes.ui.recipe
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,11 +25,10 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun StepCard(step: Step) {
-    Card(
+    ElevatedCard(
         modifier = Modifier
             .width(600.dp)
-            .padding(8.dp),
-        elevation = 10.dp
+            .padding(8.dp)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -46,11 +45,11 @@ fun StepCard(step: Step) {
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .size(50.dp)
-                        .border(1.dp, MaterialTheme.colors.onBackground, CircleShape)
+                        .border(1.dp, MaterialTheme.colorScheme.onBackground, CircleShape)
                 ) {
                     Text(
                         text = step.number.toString(),
-                        style = MaterialTheme.typography.h6.copy(
+                        style = MaterialTheme.typography.titleLarge.copy(
                             fontSize = 22.sp,
                             textAlign = TextAlign.Center
                         )
@@ -58,12 +57,12 @@ fun StepCard(step: Step) {
                 }
                 Text(
                     text = step.step,
-                    style = MaterialTheme.typography.body1
+                    style = MaterialTheme.typography.bodyLarge
                 )
             }
 
             if (step.ingredients.isNotEmpty()) {
-                Divider()
+                HorizontalDivider()
 
                 // Ingredients for each step
                 Row(
@@ -72,7 +71,7 @@ fun StepCard(step: Step) {
                 ) {
                     Text(
                         text = stringResource(R.string.ingredients),
-                        style = MaterialTheme.typography.subtitle1.copy(
+                        style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Bold
                         )
                     )
@@ -93,7 +92,7 @@ fun StepCard(step: Step) {
                                 )
                                 Text(
                                     text = ingredient.name,
-                                    style = MaterialTheme.typography.body2.copy(
+                                    style = MaterialTheme.typography.bodyMedium.copy(
                                         textAlign = TextAlign.Center
                                     ),
                                     modifier = Modifier.width(100.dp)
@@ -105,7 +104,7 @@ fun StepCard(step: Step) {
             }
 
             if (step.equipment.isNotEmpty()) {
-                Divider()
+                HorizontalDivider()
 
                 // Equipment for each step
                 Row(
@@ -114,7 +113,7 @@ fun StepCard(step: Step) {
                 ) {
                     Text(
                         text = stringResource(R.string.equipment),
-                        style = MaterialTheme.typography.subtitle1.copy(
+                        style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Bold
                         )
                     )
@@ -133,7 +132,7 @@ fun StepCard(step: Step) {
                                 )
                                 Text(
                                     text = equipment.name,
-                                    style = MaterialTheme.typography.body2.copy(
+                                    style = MaterialTheme.typography.bodyMedium.copy(
                                         textAlign = TextAlign.Center
                                     ),
                                     modifier = Modifier.width(100.dp)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
@@ -29,7 +29,7 @@ import com.abhiek.ezrecipes.utils.HTMLText
 fun SummaryBox(summary: String) {
     Box(
         modifier = Modifier
-            .background(MaterialTheme.colorScheme.secondary)
+            .background(MaterialTheme.colorScheme.tertiary)
     ) {
         Column(
             modifier = Modifier.padding(16.dp)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/SummaryBox.kt
@@ -2,12 +2,12 @@ package com.abhiek.ezrecipes.ui.recipe
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.TipsAndUpdates
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,7 +29,7 @@ import com.abhiek.ezrecipes.utils.HTMLText
 fun SummaryBox(summary: String) {
     Box(
         modifier = Modifier
-            .background(MaterialTheme.colors.secondary)
+            .background(MaterialTheme.colorScheme.secondary)
     ) {
         Column(
             modifier = Modifier.padding(16.dp)
@@ -43,7 +43,7 @@ fun SummaryBox(summary: String) {
             ) {
                 Text(
                     text = stringResource(R.string.summary),
-                    style = MaterialTheme.typography.h6.copy(
+                    style = MaterialTheme.typography.titleLarge.copy(
                         color = Color.Black,
                         fontWeight = FontWeight.Bold,
                         textAlign = TextAlign.Center

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/CheckboxRow.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/CheckboxRow.kt
@@ -6,10 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,7 +40,12 @@ fun CheckboxRow(
         )
         Checkbox(
             checked = checked,
-            onCheckedChange = null
+            onCheckedChange = null,
+            colors = CheckboxDefaults.colors().copy(
+                checkedBoxColor = MaterialTheme.colorScheme.tertiary,
+                checkedCheckmarkColor = MaterialTheme.colorScheme.onTertiary,
+                checkedBorderColor = MaterialTheme.colorScheme.tertiary
+            )
         )
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/CheckboxRow.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/CheckboxRow.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Checkbox
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,7 +39,7 @@ fun CheckboxRow(
     ) {
         Text(
             text = stringResource(stringId),
-            style = MaterialTheme.typography.subtitle1
+            style = MaterialTheme.typography.titleMedium
         )
         Checkbox(
             checked = checked,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/FilterForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/FilterForm.kt
@@ -5,9 +5,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -185,8 +185,8 @@ fun FilterForm(
             ) {
                 Text(
                     text = stringResource(R.string.calorie_exceed_max_error),
-                    style = MaterialTheme.typography.caption.copy(
-                        color = MaterialTheme.colors.error
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.error
                     )
                 )
             }
@@ -203,8 +203,8 @@ fun FilterForm(
             ) {
                 Text(
                     text = stringResource(R.string.calorie_invalid_range_error),
-                    style = MaterialTheme.typography.caption.copy(
-                        color = MaterialTheme.colors.error
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.error
                     )
                 )
             }
@@ -314,8 +314,8 @@ fun FilterForm(
             if (searchViewModel.noRecipesFound) {
                 Text(
                     text = stringResource(R.string.no_results),
-                    style = MaterialTheme.typography.body1.copy(
-                        color = MaterialTheme.colors.error
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        color = MaterialTheme.colorScheme.error
                     ),
                     modifier = Modifier.padding(start = 8.dp)
                 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
@@ -86,19 +86,6 @@ fun <T> MultiSelectDropdown(
                     },
                     onClick = { onSelectOption(option) }
                 )
-//                ) {
-//                    Row(
-//                        horizontalArrangement = Arrangement.SpaceBetween,
-//                        verticalAlignment = Alignment.CenterVertically,
-//                        modifier = Modifier.fillMaxWidth()
-//                    ) {
-//                        Text(option.toString())
-//                        Checkbox(
-//                            checked = value.contains(option),
-//                            onCheckedChange = null
-//                        )
-//                    }
-//                }
             }
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
@@ -80,7 +80,12 @@ fun <T> MultiSelectDropdown(
                             Text(option.toString())
                             Checkbox(
                                 checked = value.contains(option),
-                                onCheckedChange = null
+                                onCheckedChange = null,
+                                colors = CheckboxDefaults.colors().copy(
+                                    checkedBoxColor = MaterialTheme.colorScheme.tertiary,
+                                    checkedCheckmarkColor = MaterialTheme.colorScheme.onTertiary,
+                                    checkedBorderColor = MaterialTheme.colorScheme.tertiary
+                                )
                             )
                         }
                     },

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/MultiSelectDropdown.kt
@@ -2,10 +2,10 @@ package com.abhiek.ezrecipes.ui.search
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,11 +48,11 @@ fun <T> MultiSelectDropdown(
                 )
             },
             // Make the dropdown appear clickable instead of grayed out
-            colors = TextFieldDefaults.outlinedTextFieldColors(
-                disabledBorderColor = MaterialTheme.colors.onSurface,
-                disabledLabelColor = MaterialTheme.colors.onSurface,
-                disabledTextColor = MaterialTheme.colors.onSurface,
-                disabledTrailingIconColor = MaterialTheme.colors.onSurface
+            colors = OutlinedTextFieldDefaults.colors(
+                disabledBorderColor = MaterialTheme.colorScheme.onSurface,
+                disabledLabelColor = MaterialTheme.colorScheme.onSurface,
+                disabledTextColor = MaterialTheme.colorScheme.onSurface,
+                disabledTrailingIconColor = MaterialTheme.colorScheme.onSurface
             ),
             modifier = Modifier
                 .clickable { expanded = !expanded }
@@ -71,20 +71,34 @@ fun <T> MultiSelectDropdown(
         ) {
             options.forEach { option ->
                 DropdownMenuItem(
+                    text = {
+                        Row(
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(option.toString())
+                            Checkbox(
+                                checked = value.contains(option),
+                                onCheckedChange = null
+                            )
+                        }
+                    },
                     onClick = { onSelectOption(option) }
-                ) {
-                    Row(
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(option.toString())
-                        Checkbox(
-                            checked = value.contains(option),
-                            onCheckedChange = null
-                        )
-                    }
-                }
+                )
+//                ) {
+//                    Row(
+//                        horizontalArrangement = Arrangement.SpaceBetween,
+//                        verticalAlignment = Alignment.CenterVertically,
+//                        modifier = Modifier.fillMaxWidth()
+//                    ) {
+//                        Text(option.toString())
+//                        Checkbox(
+//                            checked = value.contains(option),
+//                            onCheckedChange = null
+//                        )
+//                    }
+//                }
             }
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
@@ -2,10 +2,10 @@ package com.abhiek.ezrecipes.ui.search
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,12 +33,11 @@ fun RecipeCard(recipe: Recipe, width: Dp? = null, onClick: () -> Unit) {
 
     val calories = recipe.nutrients.firstOrNull { nutrient -> nutrient.name == "Calories" }
 
-    Card(
+    ElevatedCard(
         modifier = Modifier
             .padding(8.dp)
             .clickable { onClick() }
-            .then(if (width != null) Modifier.width(width) else Modifier),
-        elevation = 2.dp
+            .then(if (width != null) Modifier.width(width) else Modifier)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -53,7 +52,7 @@ fun RecipeCard(recipe: Recipe, width: Dp? = null, onClick: () -> Unit) {
                     .padding(8.dp),
                 contentScale = ContentScale.Fit
             )
-            Divider()
+            HorizontalDivider()
 
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -61,7 +60,7 @@ fun RecipeCard(recipe: Recipe, width: Dp? = null, onClick: () -> Unit) {
             ) {
                 Text(
                     text = recipe.name,
-                    style = MaterialTheme.typography.h6,
+                    style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.weight(1f)
                 )
                 IconButton(onClick = { isFavorite = !isFavorite }) {
@@ -70,7 +69,7 @@ fun RecipeCard(recipe: Recipe, width: Dp? = null, onClick: () -> Unit) {
                             else Icons.Filled.FavoriteBorder,
                         contentDescription = if (isFavorite) stringResource(R.string.un_favorite_alt)
                             else stringResource(R.string.favorite_alt),
-                        tint = MaterialTheme.colors.primary
+                        tint = MaterialTheme.colorScheme.primary
                     )
                 }
             }
@@ -85,12 +84,12 @@ fun RecipeCard(recipe: Recipe, width: Dp? = null, onClick: () -> Unit) {
                         text = context.resources.getQuantityString(R.plurals.recipe_time, recipe.time, recipe.time),
                         endIndex = 5 // "Time:".length = 5
                     ),
-                    style = MaterialTheme.typography.subtitle1
+                    style = MaterialTheme.typography.titleMedium
                 )
                 calories?.let { calorie ->
                     Text(
                         text = "${calorie.amount.roundToInt()} ${calorie.unit}",
-                        style = MaterialTheme.typography.subtitle1
+                        style = MaterialTheme.typography.titleMedium
                     )
                 }
             }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -4,10 +4,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -47,7 +47,7 @@ fun SearchResults(
     ) {
         Text(
             text = stringResource(R.string.results_title),
-            style = MaterialTheme.typography.h5.copy(
+            style = MaterialTheme.typography.headlineSmall.copy(
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center
             ),
@@ -59,7 +59,7 @@ fun SearchResults(
             // Center vertically & horizontally
             Text(
                 text = stringResource(R.string.results_placeholder),
-                style = MaterialTheme.typography.h6.copy(
+                style = MaterialTheme.typography.titleLarge.copy(
                     textAlign = TextAlign.Center
                 ),
                 modifier = Modifier

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SubmitButton.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SubmitButton.kt
@@ -90,23 +90,6 @@ fun SubmitButton(searchViewModel: SearchViewModel, enabled: Boolean) {
                             text = stringResource(R.string.ok_button)
                         )
                     }
-                    // Position the button at the bottom right of the alert
-//                    Row(
-//                        modifier = Modifier
-//                            .padding(8.dp)
-//                            .fillMaxWidth(),
-//                        horizontalArrangement = Arrangement.End
-//                    ) {
-//                        Button(
-//                            onClick = {
-//                                searchViewModel.showRecipeAlert = false
-//                            }
-//                        ) {
-//                            Text(
-//                                text = stringResource(R.string.ok_button)
-//                            )
-//                        }
-//                    }
                 },
                 modifier = Modifier.padding(horizontal = 8.dp)
             )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SubmitButton.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SubmitButton.kt
@@ -1,7 +1,7 @@
 package com.abhiek.ezrecipes.ui.search
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -80,24 +80,33 @@ fun SubmitButton(searchViewModel: SearchViewModel, enabled: Boolean) {
                         stringResource(R.string.unknown_error)
                     )
                 },
-                buttons = {
-                    // Position the button at the bottom right of the alert
-                    Row(
-                        modifier = Modifier
-                            .padding(8.dp)
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        Button(
-                            onClick = {
-                                searchViewModel.showRecipeAlert = false
-                            }
-                        ) {
-                            Text(
-                                text = stringResource(R.string.ok_button)
-                            )
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            searchViewModel.showRecipeAlert = false
                         }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.ok_button)
+                        )
                     }
+                    // Position the button at the bottom right of the alert
+//                    Row(
+//                        modifier = Modifier
+//                            .padding(8.dp)
+//                            .fillMaxWidth(),
+//                        horizontalArrangement = Arrangement.End
+//                    ) {
+//                        Button(
+//                            onClick = {
+//                                searchViewModel.showRecipeAlert = false
+//                            }
+//                        ) {
+//                            Text(
+//                                text = stringResource(R.string.ok_button)
+//                            )
+//                        }
+//                    }
                 },
                 modifier = Modifier.padding(horizontal = 8.dp)
             )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Shape.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Shape.kt
@@ -1,7 +1,7 @@
 package com.abhiek.ezrecipes.ui.theme
 
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Shapes
+import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
 val Shapes = Shapes(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Theme.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Theme.kt
@@ -1,21 +1,21 @@
 package com.abhiek.ezrecipes.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 
-private val DarkColorPalette = darkColors(
+private val DarkColorPalette = darkColorScheme(
     primary = Blue300,
-    primaryVariant = Blue700,
-    secondary = Amber300
+    secondary = Blue700,
+    tertiary = Amber300
 )
 
-private val LightColorPalette = lightColors(
+private val LightColorPalette = lightColorScheme(
     primary = Blue500,
-    primaryVariant = Blue700,
-    secondary = Amber300
+    secondary = Blue700,
+    tertiary = Amber300
 
     /* Other default colors to override
     background = Color.White,
@@ -36,7 +36,7 @@ fun EZRecipesTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composa
     }
 
     MaterialTheme(
-        colors = colors,
+        colorScheme = colors,
         typography = Typography,
         shapes = Shapes,
         content = content

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Theme.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Theme.kt
@@ -11,6 +11,7 @@ private val DarkColorPalette = darkColorScheme(
     primary = Blue300,
     secondary = Blue700,
     tertiary = Amber300,
+    onPrimary = Color.Black,
     onTertiary = Color.Black
 )
 
@@ -18,6 +19,7 @@ private val LightColorPalette = lightColorScheme(
     primary = Blue500,
     secondary = Blue700,
     tertiary = Amber300,
+    onPrimary = Color.Black,
     onTertiary = Color.Black
 
     /* Other default colors to override

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Theme.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Theme.kt
@@ -5,17 +5,20 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = darkColorScheme(
     primary = Blue300,
     secondary = Blue700,
-    tertiary = Amber300
+    tertiary = Amber300,
+    onTertiary = Color.Black
 )
 
 private val LightColorPalette = lightColorScheme(
     primary = Blue500,
     secondary = Blue700,
-    tertiary = Amber300
+    tertiary = Amber300,
+    onTertiary = Color.Black
 
     /* Other default colors to override
     background = Color.White,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Type.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Type.kt
@@ -1,6 +1,6 @@
 package com.abhiek.ezrecipes.ui.theme
 
-import androidx.compose.material.Typography
+import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -8,7 +8,7 @@ import androidx.compose.ui.unit.sp
 
 // Set of Material typography styles to start with
 val Typography = Typography(
-    body1 = TextStyle(
+    bodyLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/HTMLText.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/HTMLText.kt
@@ -4,7 +4,7 @@ import android.text.method.LinkMovementMethod
 import android.util.TypedValue
 import android.widget.TextView
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Surface
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color


### PR DESCRIPTION
I caved in and migrated from M2 to M3 to support edge-to-edge.

| Screen | Material 2 | Material 3 |
| - | - | - |
| Home | <img src="https://github.com/user-attachments/assets/73a9e738-3d37-40a2-8562-f47ae7f665ae" alt="1_en-US" width="300"> <img src="https://github.com/user-attachments/assets/4735ead9-0fc5-433f-9d3f-9b5c26cbeca8" alt="1_en-US" width="300"> <img src="https://github.com/user-attachments/assets/ad64fddd-a08e-4f7a-abd7-765113c804d1" alt="5_en-US" width="600"> | <img src="https://github.com/user-attachments/assets/6002986b-6cf5-4e15-b047-85dc82f278e1" alt="home-sm" width="300"><img src="https://github.com/user-attachments/assets/d1c9c629-5f28-4546-a7be-295771a2f44e" alt="home-md" width="300"> <img src="https://github.com/user-attachments/assets/bb14aeaa-f175-4441-8567-0b90e4f79bcf" alt="home-lg" width="600"> |
| Recipe | <img src="https://github.com/user-attachments/assets/15b42fca-7961-4e9f-a326-9b44314527a7" alt="2_en-US" width="300"> <img src="https://github.com/user-attachments/assets/21f8f0fa-a75b-4ab3-81ad-10ce52b932ef" alt="3_en-US" width="300"> <img src="https://github.com/user-attachments/assets/d7b8c367-d5d7-4d0b-ba27-5ca7e9cb6f9b" alt="4_en-US" width="300"> <img src="https://github.com/user-attachments/assets/b77a7169-a77d-411f-8ce9-f81b914f2b68" alt="5_en-US" width="300"> | <img src="https://github.com/user-attachments/assets/ce5b8be9-ef41-47db-a463-2f8965c78299" alt="recipe-1" width="300"> <img src="https://github.com/user-attachments/assets/838943a9-d7de-40d6-964a-530517a1dc87" alt="recipe-2" width="300"> <img src="https://github.com/user-attachments/assets/f0ad36f5-390d-479c-8d8a-1ec8af9cc67d" alt="recipe-3" width="300"> <img src="https://github.com/user-attachments/assets/a8d4b26d-a6a2-4d26-93f0-c98b0b1d1fd0" alt="recipe-4" width="300"> |
| Filter Form | <img src="https://github.com/user-attachments/assets/2e5d9805-7d05-4375-863f-847f30332d33" alt="6_en-US" width="300"> | <img src="https://github.com/user-attachments/assets/7fb71f48-2f2d-484e-a33e-538f668af439" alt="filter-form" width="300"> |
| Search Results | <img src="https://github.com/user-attachments/assets/33cb31c3-dc3f-435e-9277-3b6d90039fbc" alt="7_en-US" width="300"> | <img src="https://github.com/user-attachments/assets/5b2473d9-2b5e-4ad1-918a-a69f58d548ee" alt="search-results" width="300"> |
| Glossary | <img src="https://github.com/user-attachments/assets/b354a1a3-e73d-4417-a9ec-43f7713bdc2a" alt="8_en-US" width="300"> | <img src="https://github.com/user-attachments/assets/2ea8de94-982a-48e3-9ae4-1563352d526d" alt="glossary" width="300"> |

Here were some highlights during the migration:

- Changed all `androidx.compose.material.*` imports to `androidx.compose.material3.*`
- Updated theme to support new [colors](https://developer.android.com/develop/ui/compose/designsystems/material2-material3#color) & [typography](https://developer.android.com/develop/ui/compose/designsystems/material2-material3#typography)
- Renamed BottomNavigation & BottomNavigationItem to NavigationBar & NavigationBarItem
- Since drawer properties are no longer included in the Scaffold, there was a huge migration to put the ModalNavigationDrawer & ModalDrawerSheet above the Scaffold at the root of the UI, but only on large screens
  - So now it's setContent --> ModalNavigationDrawer --> Scaffold --> NavHost --> composable
- Used HorizontalDivider instead of Divider & ElevatedCard instead of Card
- Changed some parameters for things like AlertDialog & DropdownMenuItem
- Buttons are rounder
- Alerts are rounder
- The previews kept getting the secondary and tertiary colors confused
- The following are currently experimental
  - WindowSizeClass
  - TopAppBar
  - FlowRow
  - Certain coroutine APIs for testing