### PR TITLE
Profile Pt 1: Profile Tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .gradle/
 build/
 
+# Kotlin compilation data
+.kotlin/
+
 # Local configuration file (sdk path, etc)
 local.properties
 

--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -72,14 +73,14 @@ android {
 }
 
 dependencies {
-    val composeBomVersion = "2024.09.03"
-    val googlePlayVersion = "2.0.1"
+    val composeBomVersion = "2024.10.00"
     val lifecycleVersion = "2.8.6"
-    val activityVersion = "1.9.2"
-    val materialVersion = "1.7.3"
+    val activityVersion = "1.9.3"
+    val materialVersion = "1.7.4"
     val material3Version = "1.3.0"
     val retrofitVersion = "2.11.0"
     val roomVersion = "2.6.1"
+    val googlePlayVersion = "2.0.2"
     val jupiterVersion = "5.11.1"
     val espressoVersion = "3.6.1"
 
@@ -95,7 +96,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended:$materialVersion")
     implementation("androidx.compose.material3:material3:$material3Version")
     implementation("androidx.compose.material3:material3-window-size-class:$material3Version")
-    implementation("androidx.navigation:navigation-compose:2.8.2")
+    implementation("androidx.navigation:navigation-compose:2.8.3")
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 
     // AsyncImage

--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -73,19 +73,19 @@ android {
 }
 
 dependencies {
-    val composeBomVersion = "2024.10.00"
-    val lifecycleVersion = "2.8.6"
+    val composeBomVersion = "2024.10.01"
+    val lifecycleVersion = "2.8.7"
     val activityVersion = "1.9.3"
-    val materialVersion = "1.7.4"
-    val material3Version = "1.3.0"
+    val materialVersion = "1.7.5"
+    val material3Version = "1.3.1"
     val retrofitVersion = "2.11.0"
     val roomVersion = "2.6.1"
     val googlePlayVersion = "2.0.2"
-    val jupiterVersion = "5.11.1"
+    val jupiterVersion = "5.11.3"
     val espressoVersion = "3.6.1"
 
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
-    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion")
@@ -119,8 +119,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
-    testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    testImplementation("io.mockk:mockk:1.13.13")
 
     androidTestImplementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     androidTestImplementation("androidx.test.ext:junit:1.2.1")

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefRepository.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefRepository.kt
@@ -1,0 +1,98 @@
+package com.abhiek.ezrecipes.data.chef
+
+import com.abhiek.ezrecipes.data.models.*
+import com.abhiek.ezrecipes.utils.Constants
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import retrofit2.Response
+
+class ChefRepository(private val chefService: ChefService) {
+    private fun <T> parseResponse(response: Response<T>): ChefResult<T> {
+        // isSuccessful means a 2xx response code
+        return if (response.isSuccessful && response.body() != null) {
+            ChefResult.Success(response.body()!!)
+        } else {
+            val errorString = response.errorBody()?.string()
+
+            val recipeError = try {
+                // Try to parse the response as a RecipeError
+                Gson().fromJson(errorString, RecipeError::class.java)
+            } catch (error: JsonSyntaxException) {
+                // Otherwise, set the error property as the raw error string
+                RecipeError(errorString ?: Constants.UNKNOWN_ERROR)
+            }
+
+            return ChefResult.Error(recipeError)
+        }
+    }
+
+    suspend fun getChef(token: String): ChefResult<Chef> {
+        return try {
+            val response = chefService.getChef(token)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            ChefResult.Error(recipeError)
+        }
+    }
+
+    suspend fun createChef(credentials: LoginCredentials): ChefResult<LoginResponse> {
+        return try {
+            val response = chefService.createChef(credentials)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            ChefResult.Error(recipeError)
+        }
+    }
+
+    suspend fun updateChef(fields: ChefUpdate, token: String? = null): ChefResult<ChefEmailResponse> {
+        return try {
+            val response = chefService.updateChef(fields, token)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            ChefResult.Error(recipeError)
+        }
+    }
+
+    suspend fun deleteChef(token: String): ChefResult<Void> {
+        return try {
+            val response = chefService.deleteChef(token)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            ChefResult.Error(recipeError)
+        }
+    }
+
+    suspend fun verifyEmail(token: String): ChefResult<ChefEmailResponse> {
+        return try {
+            val response = chefService.verifyEmail(token)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            ChefResult.Error(recipeError)
+        }
+    }
+
+    suspend fun login(credentials: LoginCredentials): ChefResult<LoginResponse> {
+        return try {
+            val response = chefService.login(credentials)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            ChefResult.Error(recipeError)
+        }
+    }
+
+    suspend fun logout(token: String): ChefResult<Void> {
+        return try {
+            val response = chefService.logout(token)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            ChefResult.Error(recipeError)
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefResult.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefResult.kt
@@ -1,0 +1,8 @@
+package com.abhiek.ezrecipes.data.chef
+
+import com.abhiek.ezrecipes.data.models.RecipeError
+
+sealed class ChefResult<out T> {
+    data class Success<T>(val response: T): ChefResult<T>()
+    data class Error(val recipeError: RecipeError): ChefResult<Nothing>()
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefService.kt
@@ -1,0 +1,76 @@
+package com.abhiek.ezrecipes.data.chef
+
+import com.abhiek.ezrecipes.data.models.*
+import com.abhiek.ezrecipes.utils.Constants
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.*
+import java.util.concurrent.TimeUnit
+
+interface ChefService {
+    @GET(".")
+    suspend fun getChef(
+        @Header("Authorization") token: String
+    ): Response<Chef>
+
+    @POST(".")
+    suspend fun createChef(
+        @Body credentials: LoginCredentials
+    ): Response<LoginResponse>
+
+    @PATCH(".")
+    suspend fun updateChef(
+        @Body fields: ChefUpdate,
+        @Header("Authorization") token: String? = null
+    ): Response<ChefEmailResponse>
+
+    @DELETE(".")
+    suspend fun deleteChef(
+        @Header("Authorization") token: String
+    ): Response<Void> // empty response
+
+    @POST("verify")
+    suspend fun verifyEmail(
+        @Header("Authorization") token: String
+    ): Response<ChefEmailResponse>
+
+    @POST("login")
+    suspend fun login(
+        @Body credentials: LoginCredentials
+    ): Response<LoginResponse>
+
+    @POST("logout")
+    suspend fun logout(
+        @Header("Authorization") token: String
+    ): Response<Void>
+
+    companion object {
+        private lateinit var chefService: ChefService
+
+        val instance: ChefService
+            get() {
+                if (Companion::chefService.isInitialized) return chefService
+
+                val loggingInterceptor = HttpLoggingInterceptor().setLevel(
+                    HttpLoggingInterceptor.Level.BODY
+                )
+                val httpClient = OkHttpClient().newBuilder()
+                    .addInterceptor(loggingInterceptor)
+                    .readTimeout(Constants.TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .connectTimeout(Constants.TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .build()
+
+                val retrofit = Retrofit.Builder()
+                    .baseUrl(Constants.SERVER_BASE_URL + Constants.CHEFS_PATH)
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .client(httpClient)
+                    .build()
+
+                chefService = retrofit.create(ChefService::class.java)
+                return chefService
+            }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/MockChefService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/MockChefService.kt
@@ -1,0 +1,85 @@
+package com.abhiek.ezrecipes.data.chef
+
+import com.abhiek.ezrecipes.data.models.*
+import com.abhiek.ezrecipes.utils.Constants
+import okhttp3.ResponseBody.Companion.toResponseBody
+import retrofit2.Response
+
+object MockChefService: ChefService {
+    var isSuccess = true
+    val chef = Constants.Mocks.CHEF
+    private val loginResponse = LoginResponse(
+        uid = chef.uid,
+        token = chef.token,
+        emailVerified = true
+    )
+    private val chefEmailResponse = ChefEmailResponse(
+        kind = "identitytoolkit#GetOobConfirmationCodeResponse",
+        email = chef.email,
+        token = chef.token
+    )
+
+    private const val TOKEN_ERROR_STRING =
+        "{\"error\":\"Invalid Firebase token provided: Error: Decoding Firebase ID token failed. Make sure you passed the entire string JWT which represents an ID token. See https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on how to retrieve an ID token.\"}"
+    val tokenError =
+        RecipeError(error = "Invalid Firebase token provided: Error: Decoding Firebase ID token failed. Make sure you passed the entire string JWT which represents an ID token. See https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on how to retrieve an ID token.")
+
+    override suspend fun getChef(token: String): Response<Chef> {
+        return if (isSuccess) {
+            Response.success(chef)
+        } else {
+            Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
+        }
+    }
+
+    override suspend fun createChef(credentials: LoginCredentials): Response<LoginResponse> {
+        return if (isSuccess) {
+            Response.success(loginResponse)
+        } else {
+            Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
+        }
+    }
+
+    override suspend fun updateChef(
+        fields: ChefUpdate,
+        token: String?
+    ): Response<ChefEmailResponse> {
+        return if (isSuccess) {
+            Response.success(chefEmailResponse)
+        } else {
+            Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
+        }
+    }
+
+    override suspend fun deleteChef(token: String): Response<Void> {
+        return if (isSuccess) {
+            Response.success(null)
+        } else {
+            Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
+        }
+    }
+
+    override suspend fun verifyEmail(token: String): Response<ChefEmailResponse> {
+        return if (isSuccess) {
+            Response.success(chefEmailResponse)
+        } else {
+            Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
+        }
+    }
+
+    override suspend fun login(credentials: LoginCredentials): Response<LoginResponse> {
+        return if (isSuccess) {
+            Response.success(loginResponse)
+        } else {
+            Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
+        }
+    }
+
+    override suspend fun logout(token: String): Response<Void> {
+        return if (isSuccess) {
+            Response.success(null)
+        } else {
+            Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/AuthState.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/AuthState.kt
@@ -1,0 +1,7 @@
+package com.abhiek.ezrecipes.data.models
+
+enum class AuthState {
+    UNAUTHENTICATED,
+    AUTHENTICATED,
+    LOADING
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
@@ -1,6 +1,6 @@
 package com.abhiek.ezrecipes.data.models
 
-data class Profile(
+data class Chef(
     val uid: String,
     val email: String,
     val ratings: Map<String, Int>,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/ChefEmailResponse.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/ChefEmailResponse.kt
@@ -1,0 +1,7 @@
+package com.abhiek.ezrecipes.data.models
+
+data class ChefEmailResponse(
+    val kind: String,
+    val email: String,
+    var token: String? = null
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/ChefUpdate.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/ChefUpdate.kt
@@ -1,0 +1,6 @@
+package com.abhiek.ezrecipes.data.models
+
+data class ChefUpdate(
+    val type: String,
+    val email: String
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Cuisine.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Cuisine.kt
@@ -35,7 +35,13 @@ enum class Cuisine {
     SOUTH_AMERICAN,
     CREOLE,
     CENTRAL_AMERICAN,
+    BBQ,
+    BARBECUE,
     UNKNOWN;
 
-    override fun toString() = name.replace("_", " ").lowercase().capitalizeWords()
+    override fun toString(): String {
+        if (name == "BBQ") return "BBQ"
+
+        return name.replace("_", " ").lowercase().capitalizeWords()
+    }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/LoginCredentials.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/LoginCredentials.kt
@@ -1,0 +1,6 @@
+package com.abhiek.ezrecipes.data.models
+
+data class LoginCredentials(
+    val email: String,
+    val password: String
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/LoginResponse.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/LoginResponse.kt
@@ -1,0 +1,7 @@
+package com.abhiek.ezrecipes.data.models
+
+data class LoginResponse(
+    val uid: String,
+    val token: String,
+    val emailVerified: Boolean
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/MealType.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/MealType.kt
@@ -30,6 +30,7 @@ enum class MealType {
     SMOOTHIE,
     COCKTAIL,
     MOCKTAIL,
+    SEASONING,
     UNKNOWN;
 
     override fun toString(): String {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Profile.kt
@@ -1,0 +1,10 @@
+package com.abhiek.ezrecipes.data.models
+
+data class Profile(
+    val uid: String,
+    val email: String,
+    val ratings: Map<String, Int>,
+    val recentRecipes: Map<String, String>,
+    val favoriteRecipes: List<String>,
+    val token: String
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Recipe.kt
@@ -24,5 +24,8 @@ data class Recipe(
     val nutrients: List<Nutrient>,
     val ingredients: List<Ingredient>,
     val instructions: List<Instruction>,
-    var token: String? = null // searchSequenceToken for pagination
+    var token: String? = null, // searchSequenceToken for pagination
+    var totalRatings: Int? = null,
+    var averageRatings: Double? = null,
+    var views: Int? = null,
 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecipeUpdate.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/RecipeUpdate.kt
@@ -1,0 +1,7 @@
+package com.abhiek.ezrecipes.data.models
+
+data class RecipeUpdate(
+    val rating: Int,
+    val view: Boolean,
+    val isFavorite: Boolean
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Token.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Token.kt
@@ -1,0 +1,6 @@
+package com.abhiek.ezrecipes.data.models
+
+data class Token(
+    // The token may not be present if it wasn't passed in the request
+    var token: String? = null
+)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/MockRecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/MockRecipeService.kt
@@ -55,4 +55,12 @@ object MockRecipeService: RecipeService {
             Response.error(401, RECIPE_ERROR_STRING.toResponseBody())
         }
     }
+
+    override suspend fun updateRecipe(fields: RecipeUpdate, token: String?): Response<Token> {
+        return if (isSuccess) {
+            Response.success(Token())
+        } else {
+            Response.error(401, RECIPE_ERROR_STRING.toResponseBody())
+        }
+    }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/MockRecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/MockRecipeService.kt
@@ -56,7 +56,9 @@ object MockRecipeService: RecipeService {
         }
     }
 
-    override suspend fun updateRecipe(fields: RecipeUpdate, token: String?): Response<Token> {
+    override suspend fun updateRecipe(
+        id: Int, fields: RecipeUpdate, token: String?
+    ): Response<Token> {
         return if (isSuccess) {
             Response.success(Token())
         } else {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeRepository.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeRepository.kt
@@ -74,9 +74,11 @@ class RecipeRepository(
         }
     }
 
-    suspend fun updateRecipe(fields: RecipeUpdate, token: String? = null): RecipeResult<Token> {
+    suspend fun updateRecipe(
+        id: Int, fields: RecipeUpdate, token: String? = null
+    ): RecipeResult<Token> {
         return try {
-            val response = recipeService.updateRecipe(fields, token)
+            val response = recipeService.updateRecipe(id, fields, token)
             parseResponse(response)
         } catch (error: Exception) {
             val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeRepository.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeRepository.kt
@@ -1,9 +1,6 @@
 package com.abhiek.ezrecipes.data.recipe
 
-import com.abhiek.ezrecipes.data.models.RecentRecipe
-import com.abhiek.ezrecipes.data.models.Recipe
-import com.abhiek.ezrecipes.data.models.RecipeError
-import com.abhiek.ezrecipes.data.models.RecipeFilter
+import com.abhiek.ezrecipes.data.models.*
 import com.abhiek.ezrecipes.data.storage.RecentRecipeDao
 import com.abhiek.ezrecipes.utils.Constants
 import com.google.gson.Gson
@@ -70,6 +67,16 @@ class RecipeRepository(
     suspend fun getRecipeById(id: Int): RecipeResult<Recipe> {
         return try {
             val response = recipeService.getRecipeById(id)
+            parseResponse(response)
+        } catch (error: Exception) {
+            val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)
+            return RecipeResult.Error(recipeError)
+        }
+    }
+
+    suspend fun updateRecipe(fields: RecipeUpdate, token: String? = null): RecipeResult<Token> {
+        return try {
+            val response = recipeService.updateRecipe(fields, token)
             parseResponse(response)
         } catch (error: Exception) {
             val recipeError = RecipeError(error.localizedMessage ?: Constants.UNKNOWN_ERROR)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeService.kt
@@ -11,11 +11,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.http.GET
-import retrofit2.http.Path
-import retrofit2.http.Query
-import retrofit2.http.QueryMap
-import retrofit2.http.QueryName
+import retrofit2.http.*
 import java.util.concurrent.TimeUnit
 
 // The DataSource for the recipes API
@@ -45,6 +41,12 @@ interface RecipeService {
     suspend fun getRecipeById(
         @Path("id") id: Int
     ): Response<Recipe>
+
+    @PATCH("{id}")
+    suspend fun updateRecipe(
+        @Body fields: RecipeUpdate,
+        @Header("Authorization") token: String? = null,
+    ): Response<Token>
 
     companion object {
         private lateinit var recipeService: RecipeService

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/recipe/RecipeService.kt
@@ -44,6 +44,7 @@ interface RecipeService {
 
     @PATCH("{id}")
     suspend fun updateRecipe(
+        @Path("id") id: Int,
         @Body fields: RecipeUpdate,
         @Header("Authorization") token: String? = null,
     ): Response<Token>

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/terms/MockTermsService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/terms/MockTermsService.kt
@@ -6,10 +6,8 @@ import com.abhiek.ezrecipes.utils.Constants
 import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 
-// Send hardcoded recipe responses for tests
-// Using an object to create a singleton to pass to the repository
 object MockTermsService: TermsService {
-    var isSuccess = true // controls whether the mock API calls succeed or fail
+    var isSuccess = true
     val terms = Constants.Mocks.TERMS
 
     private const val RECIPE_ERROR_STRING =

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/BottomBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/BottomBar.kt
@@ -14,30 +14,29 @@ import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.Constants
 
 @Composable
 fun BottomBar(navController: NavHostController) {
-    val bottomNavBarItems = listOf(Tab.Home, Tab.Search, Tab.Glossary)
-
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
 
     NavigationBar(
         containerColor = MaterialTheme.colorScheme.primary
     ) {
-        bottomNavBarItems.forEach { item ->
+        Constants.TABS.forEach { tab ->
             NavigationBarItem(
-                icon = { Icon(item.icon, contentDescription = null) },
-                label = { Text(stringResource(item.resourceId)) },
+                icon = { Icon(tab.icon, contentDescription = null) },
+                label = { Text(stringResource(tab.resourceId)) },
                 // Keep the tab selected as long as it matches one of the parent routes
-                selected = currentDestination?.hierarchy?.any { it.route == item.route } == true,
+                selected = currentDestination?.hierarchy?.any { it.route == tab.route } == true,
                 colors = NavigationBarItemDefaults.colors().copy(
                     selectedTextColor = MaterialTheme.colorScheme.onPrimary,
                     unselectedIconColor = MaterialTheme.colorScheme.onPrimary,
                     unselectedTextColor = MaterialTheme.colorScheme.onPrimary
                 ),
                 onClick = {
-                    navController.navigate(item.route) {
+                    navController.navigate(tab.route) {
                         // Pop up to the start destination of the graph to
                         // avoid building up a large stack of destinations
                         // on the back stack as users select items

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/DrawerListItem.kt
@@ -18,6 +18,8 @@ import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.Constants
+import com.abhiek.ezrecipes.utils.Tab
 
 @Composable
 fun DrawerListItem(item: Tab, selected: Boolean, onItemClick: () -> Unit) {
@@ -64,9 +66,9 @@ fun DrawerListItem(item: Tab, selected: Boolean, onItemClick: () -> Unit) {
 fun DrawerListItemPreview() {
     EZRecipesTheme {
         Column {
-            DrawerListItem(item = Tab.Home, selected = true) {}
-            DrawerListItem(item = Tab.Search, selected = false) {}
-            DrawerListItem(item = Tab.Glossary, selected = false) {}
+            Constants.TABS.forEach { tab ->
+                DrawerListItem(item = tab, selected = tab == Tab.Home) {}
+            }
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavRail.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavRail.kt
@@ -13,22 +13,21 @@ import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.Constants
 
 @Composable
 fun NavRail(navController: NavHostController) {
-    val railItems = listOf(Tab.Home, Tab.Search, Tab.Glossary)
-
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
     NavigationRail {
-        railItems.forEach { item ->
+        Constants.TABS.forEach { tab ->
             NavigationRailItem(
-                label = { Text(stringResource(item.resourceId)) },
-                icon = { Icon(item.icon, contentDescription = null) },
-                selected = currentRoute == item.route,
+                label = { Text(stringResource(tab.resourceId)) },
+                icon = { Icon(tab.icon, contentDescription = null) },
+                selected = currentRoute == tab.route,
                 onClick = {
-                    navController.navigate(item.route) {
+                    navController.navigate(tab.route) {
                         popUpTo(navController.graph.findStartDestination().id) {
                             saveState = true
                         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationDrawer.kt
@@ -31,6 +31,7 @@ import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.Constants
 import com.abhiek.ezrecipes.utils.currentWindowSize
 import com.abhiek.ezrecipes.utils.toPx
 import kotlinx.coroutines.CoroutineScope
@@ -44,10 +45,6 @@ fun NavigationDrawer(
     width: Int = 300,
     initialDrawerValue: DrawerValue = DrawerValue.Closed
 ) {
-    /* Using sealedSubclasses requires reflection, which will make the app slower,
-     * so list each drawer item manually
-     */
-    val drawerItems = listOf(Tab.Home, Tab.Search, Tab.Glossary)
     val drawerState = rememberDrawerState(initialDrawerValue)
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -97,13 +94,13 @@ fun NavigationDrawer(
                             .height(8.dp)
                     )
                     // Loop through all the subclasses of the sealed Tab class
-                    drawerItems.forEach { item ->
+                    Constants.TABS.forEach { tab ->
                         DrawerListItem(
-                            item = item,
+                            item = tab,
                             // Highlight the drawer item corresponding to the current route on screen
-                            selected = currentRoute == item.route,
+                            selected = currentRoute == tab.route,
                             onItemClick = {
-                                navController.navigate(item.route) {
+                                navController.navigate(tab.route) {
                                     popUpTo(navController.graph.findStartDestination().id) {
                                         saveState = true
                                     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -27,6 +27,9 @@ import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.profile.Profile
+import com.abhiek.ezrecipes.ui.profile.ProfileViewModel
+import com.abhiek.ezrecipes.ui.profile.ProfileViewModelFactory
 import com.abhiek.ezrecipes.ui.recipe.Recipe
 import com.abhiek.ezrecipes.ui.search.FilterForm
 import com.abhiek.ezrecipes.ui.search.SearchResults
@@ -52,6 +55,9 @@ fun NavigationGraph(
     )
     val glossaryViewModel = viewModel<GlossaryViewModel>(
         factory = GlossaryViewModelFactory(context)
+    )
+    val profileViewModel = viewModel<ProfileViewModel>(
+        factory = ProfileViewModelFactory(context)
     )
 
     // Only call once when composed
@@ -162,6 +168,11 @@ fun NavigationGraph(
             Constants.Routes.GLOSSARY
         ) {
             Glossary(glossaryViewModel.terms)
+        }
+        composable(
+            Constants.Routes.PROFILE
+        ) {
+            Profile(profileViewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -57,7 +57,7 @@ fun NavigationGraph(
         factory = GlossaryViewModelFactory(context)
     )
     val profileViewModel = viewModel<ProfileViewModel>(
-        factory = ProfileViewModelFactory(context)
+        factory = ProfileViewModelFactory()
     )
 
     // Only call once when composed

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -42,7 +42,7 @@ import com.abhiek.ezrecipes.utils.*
 fun NavigationGraph(
     navController: NavHostController,
     widthSizeClass: WindowWidthSizeClass,
-    startDestination: String = Constants.Routes.HOME
+    startDestination: String = Routes.HOME
 ) {
     val context = LocalContext.current
     val isWideScreen = widthSizeClass == WindowWidthSizeClass.Expanded
@@ -72,7 +72,7 @@ fun NavigationGraph(
         startDestination = startDestination
     ) {
         composable(
-            Constants.Routes.HOME,
+            Routes.HOME,
             // Fading in is ok when switching tabs
             exitTransition = if (mainViewModel.recipe != null) {
                 { slideLeftExit() }
@@ -83,7 +83,7 @@ fun NavigationGraph(
         ) {
             Home(mainViewModel) {
                 navController.navigate(
-                    Constants.Routes.RECIPE.replace(
+                    Routes.RECIPE.replace(
                         "{id}", mainViewModel.recipe?.id.toString()
                     )
                 ) {
@@ -93,10 +93,10 @@ fun NavigationGraph(
             }
         }
         composable(
-            Constants.Routes.RECIPE,
+            Routes.RECIPE,
             deepLinks = listOf(
                 navDeepLink {
-                    uriPattern = "${Constants.RECIPE_WEB_ORIGIN}/${Constants.Routes.RECIPE}"
+                    uriPattern = "${Constants.RECIPE_WEB_ORIGIN}/${Routes.RECIPE}"
                 }
             ),
             // Mimic sliding transitions on iOS
@@ -108,7 +108,7 @@ fun NavigationGraph(
             Recipe(mainViewModel, isWideScreen, backStackEntry.arguments?.getString("id"))
         }
         composable(
-            Constants.Routes.SEARCH,
+            Routes.SEARCH,
             exitTransition = if (searchViewModel.recipes.isNotEmpty()) {
                 { slideLeftExit() }
             } else null,
@@ -119,7 +119,7 @@ fun NavigationGraph(
             // On large screens, show the form and results side-by-side
             if (widthSizeClass == WindowWidthSizeClass.Compact) {
                 FilterForm(searchViewModel) {
-                    navController.navigate(Constants.Routes.RESULTS)
+                    navController.navigate(Routes.RESULTS)
                 }
             } else {
                 Row(
@@ -137,7 +137,7 @@ fun NavigationGraph(
                         )
                     ) {
                         navController.navigate(
-                            Constants.Routes.RECIPE.replace(
+                            Routes.RECIPE.replace(
                                 "{id}", mainViewModel.recipe?.id.toString()
                             )
                         ) {
@@ -148,7 +148,7 @@ fun NavigationGraph(
             }
         }
         composable(
-            Constants.Routes.RESULTS,
+            Routes.RESULTS,
             enterTransition = { slideLeftEnter() },
             exitTransition = { slideLeftExit() },
             popEnterTransition = { slideRightEnter() },
@@ -156,7 +156,7 @@ fun NavigationGraph(
         ) {
             SearchResults(mainViewModel, searchViewModel) {
                 navController.navigate(
-                    Constants.Routes.RECIPE.replace(
+                    Routes.RECIPE.replace(
                         "{id}", mainViewModel.recipe?.id.toString()
                     )
                 ) {
@@ -165,12 +165,12 @@ fun NavigationGraph(
             }
         }
         composable(
-            Constants.Routes.GLOSSARY
+            Routes.GLOSSARY
         ) {
             Glossary(glossaryViewModel.terms)
         }
         composable(
-            Constants.Routes.PROFILE
+            Routes.PROFILE
         ) {
             Profile(profileViewModel)
         }
@@ -179,11 +179,12 @@ fun NavigationGraph(
 
 private class NavigationGraphPreviewParameterProvider: PreviewParameterProvider<String> {
     override val values = sequenceOf(
-        Constants.Routes.HOME,
-        Constants.Routes.RECIPE,
-        Constants.Routes.SEARCH,
-        Constants.Routes.RESULTS,
-        Constants.Routes.GLOSSARY
+        Routes.HOME,
+        Routes.RECIPE,
+        Routes.SEARCH,
+        Routes.RESULTS,
+        Routes.GLOSSARY,
+        Routes.PROFILE
     )
 }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/Tab.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/Tab.kt
@@ -3,6 +3,7 @@ package com.abhiek.ezrecipes.ui.navbar
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -15,6 +16,7 @@ sealed class Tab(val route: String, @StringRes val resourceId: Int, val icon: Im
     data object Home: Tab(Constants.Routes.HOME, R.string.home_tab, Icons.Filled.Home)
     data object Search: Tab(Constants.Routes.SEARCH, R.string.search_tab, Icons.Filled.Search)
     data object Glossary: Tab(Constants.Routes.GLOSSARY, R.string.glossary_tab,
-        Icons.AutoMirrored.Filled.MenuBook
-    )
+        Icons.AutoMirrored.Filled.MenuBook)
+    data object Profile: Tab(Constants.Routes.PROFILE, R.string.profile_tab,
+        Icons.Filled.AccountCircle)
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -22,6 +22,7 @@ import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
+import com.abhiek.ezrecipes.utils.Routes
 import com.abhiek.ezrecipes.utils.currentWindowSize
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -73,7 +74,7 @@ fun TopBar(
         },
         // Add a favorite and share button on the right side if we're on the recipe screen
         actions = {
-            if (currentRoute == Constants.Routes.RECIPE) {
+            if (currentRoute == Routes.RECIPE) {
                 IconButton(onClick = { isFavorite = !isFavorite }) {
                     Icon(
                         if (isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Accordion.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Accordion.kt
@@ -1,0 +1,103 @@
+package com.abhiek.ezrecipes.ui.profile
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+
+// Source: https://stackoverflow.com/a/68995732
+@Composable
+fun Accordion(
+    header: String,
+    expandByDefault: Boolean = true,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    var isExpanded by remember { mutableStateOf(expandByDefault) }
+
+    Column(modifier) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(8.dp)
+                .clickable {
+                    isExpanded = !isExpanded
+                }
+        ) {
+            Text(
+                text = header,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontWeight = FontWeight.Bold
+                ),
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = Icons.Default.run {
+                    if (isExpanded) KeyboardArrowUp else KeyboardArrowDown
+                },
+                contentDescription = if (isExpanded) "Expanded" else "Collapsed",
+                tint = MaterialTheme.colorScheme.onSurface.copy(
+                    alpha = 0.6f
+                )
+            )
+        }
+        // Animate the content sliding when expanding or collapsing
+        AnimatedVisibility(
+            visible = isExpanded,
+            enter = expandVertically(),
+            exit = shrinkVertically()
+        ) {
+            content()
+        }
+        HorizontalDivider()
+    }
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun AccordionPreview() {
+    EZRecipesTheme {
+        Surface {
+            Column {
+                Accordion(
+                    header = "Collapsed",
+                    expandByDefault = false,
+                    content = {
+                        Text(
+                            text = "Collapsed by default",
+                            modifier = Modifier.padding(8.dp)
+                        )
+                    }
+                )
+                Accordion(
+                    header = "Expanded",
+                    content = {
+                        Text(
+                            text = "Expanded by default",
+                            modifier = Modifier.padding(8.dp)
+                        )
+                    }
+                )
+            }
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.AuthState
+import com.abhiek.ezrecipes.data.recipe.MockRecipeService
+import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -24,7 +26,7 @@ fun Profile(profileViewModel: ProfileViewModel) {
     val chef = profileViewModel.chef
 
     if (authState == AuthState.AUTHENTICATED && chef != null) {
-        ProfileLoggedIn(chef)
+        ProfileLoggedIn(chef, profileViewModel)
     } else if (authState == AuthState.UNAUTHENTICATED) {
         ProfileLoggedOut()
     } else {
@@ -58,9 +60,13 @@ private fun ProfilePreview(
     @PreviewParameter(ProfilePreviewParameterProvider::class) state: ProfileState
 ) {
     val chefService = MockChefService
-    val profileViewModel = ProfileViewModel(ChefRepository(chefService))
+    val recipeService = MockRecipeService
+    val profileViewModel = ProfileViewModel(
+        chefRepository = ChefRepository(chefService),
+        recipeRepository = RecipeRepository(recipeService)
+    )
     profileViewModel.authState = state.authState
-    profileViewModel.chef = MockChefService.chef
+    profileViewModel.chef = chefService.chef
 
     EZRecipesTheme {
         Surface {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -1,14 +1,10 @@
 package com.abhiek.ezrecipes.ui.profile
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.*
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.AuthState
@@ -23,84 +19,12 @@ fun Profile(profileViewModel: ProfileViewModel) {
     val authState = profileViewModel.authState
     val chef = profileViewModel.chef
 
-    Column {
-        if (authState == AuthState.AUTHENTICATED && chef != null) {
-            Text(
-                text = stringResource(R.string.profile_header, chef.email),
-                style = MaterialTheme.typography.titleLarge
-            )
-
-            Text(
-                text = stringResource(R.string.profile_favorites),
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold
-                )
-            )
-            Row {
-                for (id in chef.favoriteRecipes) {
-                    Text(id)
-                }
-            }
-            HorizontalDivider()
-
-            Text(
-                text = stringResource(R.string.profile_recently_viewed),
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold
-                )
-            )
-            Row {
-                for ((id, timestamp) in chef.recentRecipes.entries) {
-                    Text("$id: Recently viewed at $timestamp")
-                }
-            }
-            HorizontalDivider()
-
-            Text(
-                text = stringResource(R.string.profile_ratings),
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontWeight = FontWeight.Bold
-                )
-            )
-            Row {
-                for ((id, rating) in chef.ratings.entries) {
-                    Text("$id: $rating star(s)")
-                }
-            }
-
-            Button(
-                onClick = { println("Logout") }
-            ) {
-                Text(text = stringResource(R.string.logout))
-            }
-            Button(
-                onClick = { println("Change Email") }
-            ) {
-                Text(text = stringResource(R.string.change_email))
-            }
-            Button(
-                onClick = { println("Change Password") }
-            ) {
-                Text(text = stringResource(R.string.change_password))
-            }
-            Button(
-                onClick = { println("Delete Account") }
-            ) {
-                Text(text = stringResource(R.string.delete_account))
-            }
-        } else if (authState == AuthState.UNAUTHENTICATED) {
-            Text(
-                text = stringResource(R.string.login_message)
-            )
-
-            Button(
-                onClick = { println("Login") }
-            ) {
-                Text(text = stringResource(R.string.login))
-            }
-        } else {
-            CircularProgressIndicator()
-        }
+    if (authState == AuthState.AUTHENTICATED && chef != null) {
+        ProfileLoggedIn(chef)
+    } else if (authState == AuthState.UNAUTHENTICATED) {
+        ProfileLoggedOut()
+    } else {
+        CircularProgressIndicator()
     }
 }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -1,0 +1,133 @@
+package com.abhiek.ezrecipes.ui.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.models.AuthState
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+
+@Composable
+fun Profile(profileViewModel: ProfileViewModel) {
+    val authState = profileViewModel.authState
+    val profile = profileViewModel.profile
+
+    Column {
+        if (authState == AuthState.AUTHENTICATED && profile != null) {
+            Text(
+                text = stringResource(R.string.profile_header, profile.email),
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            Text(
+                text = stringResource(R.string.profile_favorites),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold
+                )
+            )
+            Row {
+                for (id in profile.favoriteRecipes) {
+                    Text(id)
+                }
+            }
+            HorizontalDivider()
+
+            Text(
+                text = stringResource(R.string.profile_recently_viewed),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold
+                )
+            )
+            Row {
+                for ((id, timestamp) in profile.recentRecipes.entries) {
+                    Text("$id: Recently viewed at $timestamp")
+                }
+            }
+            HorizontalDivider()
+
+            Text(
+                text = stringResource(R.string.profile_ratings),
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = FontWeight.Bold
+                )
+            )
+            Row {
+                for ((id, rating) in profile.ratings.entries) {
+                    Text("$id: $rating star(s)")
+                }
+            }
+
+            Button(
+                onClick = { println("Logout") }
+            ) {
+                Text(text = stringResource(R.string.logout))
+            }
+            Button(
+                onClick = { println("Change Email") }
+            ) {
+                Text(text = stringResource(R.string.change_email))
+            }
+            Button(
+                onClick = { println("Change Password") }
+            ) {
+                Text(text = stringResource(R.string.change_password))
+            }
+            Button(
+                onClick = { println("Delete Account") }
+            ) {
+                Text(text = stringResource(R.string.delete_account))
+            }
+        } else if (authState == AuthState.UNAUTHENTICATED) {
+            Text(
+                text = stringResource(R.string.login_message)
+            )
+
+            Button(
+                onClick = { println("Login") }
+            ) {
+                Text(text = stringResource(R.string.login))
+            }
+        } else {
+            CircularProgressIndicator()
+        }
+    }
+}
+
+private data class ProfileState(
+    val authState: AuthState
+)
+
+private class ProfilePreviewParameterProvider : PreviewParameterProvider<ProfileState> {
+    override val values = sequenceOf(
+        ProfileState(AuthState.AUTHENTICATED),
+        ProfileState(AuthState.UNAUTHENTICATED),
+        ProfileState(AuthState.LOADING)
+    )
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun ProfilePreview(
+    @PreviewParameter(ProfilePreviewParameterProvider::class) state: ProfileState
+) {
+    val profileViewModel = ProfileViewModel()
+    profileViewModel.authState = state.authState
+
+    EZRecipesTheme {
+        Surface {
+            Profile(profileViewModel)
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -1,8 +1,12 @@
 package com.abhiek.ezrecipes.ui.profile
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.abhiek.ezrecipes.data.chef.ChefRepository
@@ -24,7 +28,12 @@ fun Profile(profileViewModel: ProfileViewModel) {
     } else if (authState == AuthState.UNAUTHENTICATED) {
         ProfileLoggedOut()
     } else {
-        CircularProgressIndicator()
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
     }
 }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.chef.ChefRepository
+import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.AuthState
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -19,12 +21,12 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 @Composable
 fun Profile(profileViewModel: ProfileViewModel) {
     val authState = profileViewModel.authState
-    val profile = profileViewModel.profile
+    val chef = profileViewModel.chef
 
     Column {
-        if (authState == AuthState.AUTHENTICATED && profile != null) {
+        if (authState == AuthState.AUTHENTICATED && chef != null) {
             Text(
-                text = stringResource(R.string.profile_header, profile.email),
+                text = stringResource(R.string.profile_header, chef.email),
                 style = MaterialTheme.typography.titleLarge
             )
 
@@ -35,7 +37,7 @@ fun Profile(profileViewModel: ProfileViewModel) {
                 )
             )
             Row {
-                for (id in profile.favoriteRecipes) {
+                for (id in chef.favoriteRecipes) {
                     Text(id)
                 }
             }
@@ -48,7 +50,7 @@ fun Profile(profileViewModel: ProfileViewModel) {
                 )
             )
             Row {
-                for ((id, timestamp) in profile.recentRecipes.entries) {
+                for ((id, timestamp) in chef.recentRecipes.entries) {
                     Text("$id: Recently viewed at $timestamp")
                 }
             }
@@ -61,7 +63,7 @@ fun Profile(profileViewModel: ProfileViewModel) {
                 )
             )
             Row {
-                for ((id, rating) in profile.ratings.entries) {
+                for ((id, rating) in chef.ratings.entries) {
                     Text("$id: $rating star(s)")
                 }
             }
@@ -122,8 +124,10 @@ private class ProfilePreviewParameterProvider : PreviewParameterProvider<Profile
 private fun ProfilePreview(
     @PreviewParameter(ProfilePreviewParameterProvider::class) state: ProfileState
 ) {
-    val profileViewModel = ProfileViewModel()
+    val chefService = MockChefService
+    val profileViewModel = ProfileViewModel(ChefRepository(chefService))
     profileViewModel.authState = state.authState
+    profileViewModel.chef = MockChefService.chef
 
     EZRecipesTheme {
         Surface {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -6,9 +6,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
@@ -36,86 +37,87 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
     ) {
         Text(
             text = stringResource(R.string.profile_header, chef.email),
-            style = MaterialTheme.typography.titleLarge
+            style = MaterialTheme.typography.headlineMedium.copy(
+                textAlign = TextAlign.Center,
+            ),
+            modifier = Modifier.fillMaxWidth()
         )
 
-        Text(
-            text = stringResource(R.string.profile_favorites),
-            style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Bold
-            )
-        )
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier
-                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
+        Accordion(
+            header = stringResource(R.string.profile_favorites),
+            expandByDefault = false
         ) {
-            for (recipe in profileViewModel.favoriteRecipes) {
-                RecipeCard(
-                    recipe = recipe,
-                    width = 350.dp
-                ) {}
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+            ) {
+                for (recipe in profileViewModel.favoriteRecipes) {
+                    RecipeCard(
+                        recipe = recipe,
+                        width = 350.dp
+                    ) {}
+                }
             }
         }
-        HorizontalDivider()
 
-        Text(
-            text = stringResource(R.string.profile_recently_viewed),
-            style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Bold
-            )
-        )
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier
-                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
+        Accordion(
+            header = stringResource(R.string.profile_recently_viewed),
+            expandByDefault = false
         ) {
-            for (recipe in profileViewModel.recentRecipes) {
-                RecipeCard(
-                    recipe = recipe,
-                    width = 350.dp
-                ) {}
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+            ) {
+                for (recipe in profileViewModel.recentRecipes) {
+                    RecipeCard(
+                        recipe = recipe,
+                        width = 350.dp
+                    ) {}
+                }
             }
         }
-        HorizontalDivider()
 
-        Text(
-            text = stringResource(R.string.profile_ratings),
-            style = MaterialTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Bold
-            )
-        )
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier
-                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
+        Accordion(
+            header = stringResource(R.string.profile_ratings),
+            expandByDefault = false
         ) {
-            for (recipe in profileViewModel.ratedRecipes) {
-                RecipeCard(
-                    recipe = recipe,
-                    width = 350.dp
-                ) {}
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+            ) {
+                for (recipe in profileViewModel.ratedRecipes) {
+                    RecipeCard(
+                        recipe = recipe,
+                        width = 350.dp
+                    ) {}
+                }
             }
         }
 
         Button(
-            onClick = { println("Logout") }
+            onClick = { println("Logout") },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
             Text(text = stringResource(R.string.logout))
         }
         Button(
-            onClick = { println("Change Email") }
+            onClick = { println("Change Email") },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
             Text(text = stringResource(R.string.change_email))
         }
         Button(
-            onClick = { println("Change Password") }
+            onClick = { println("Change Password") },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
             Text(text = stringResource(R.string.change_password))
         }
@@ -123,7 +125,8 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
             onClick = { println("Delete Account") },
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.error
-            )
+            ),
+            modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
             Text(text = stringResource(R.string.delete_account))
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -1,23 +1,39 @@
 package com.abhiek.ezrecipes.ui.profile
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.Chef
+import com.abhiek.ezrecipes.data.recipe.MockRecipeService
+import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.search.RecipeCard
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
-fun ProfileLoggedIn(chef: Chef) {
-    Column {
+fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
+    // Start loading all the recipe cards
+    profileViewModel.getAllChefRecipes()
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .padding(8.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
         Text(
             text = stringResource(R.string.profile_header, chef.email),
             style = MaterialTheme.typography.titleLarge
@@ -29,9 +45,18 @@ fun ProfileLoggedIn(chef: Chef) {
                 fontWeight = FontWeight.Bold
             )
         )
-        Row {
-            for (id in chef.favoriteRecipes) {
-                Text(id)
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+        ) {
+            for (recipe in profileViewModel.favoriteRecipes) {
+                RecipeCard(
+                    recipe = recipe,
+                    width = 350.dp
+                ) {}
             }
         }
         HorizontalDivider()
@@ -42,9 +67,18 @@ fun ProfileLoggedIn(chef: Chef) {
                 fontWeight = FontWeight.Bold
             )
         )
-        Row {
-            for ((id, timestamp) in chef.recentRecipes.entries) {
-                Text("$id: Recently viewed at $timestamp")
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+        ) {
+            for (recipe in profileViewModel.recentRecipes) {
+                RecipeCard(
+                    recipe = recipe,
+                    width = 350.dp
+                ) {}
             }
         }
         HorizontalDivider()
@@ -55,9 +89,18 @@ fun ProfileLoggedIn(chef: Chef) {
                 fontWeight = FontWeight.Bold
             )
         )
-        Row {
-            for ((id, rating) in chef.ratings.entries) {
-                Text("$id: $rating star(s)")
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+        ) {
+            for (recipe in profileViewModel.ratedRecipes) {
+                RecipeCard(
+                    recipe = recipe,
+                    width = 350.dp
+                ) {}
             }
         }
 
@@ -77,7 +120,10 @@ fun ProfileLoggedIn(chef: Chef) {
             Text(text = stringResource(R.string.change_password))
         }
         Button(
-            onClick = { println("Delete Account") }
+            onClick = { println("Delete Account") },
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.error
+            )
         ) {
             Text(text = stringResource(R.string.delete_account))
         }
@@ -90,9 +136,17 @@ fun ProfileLoggedIn(chef: Chef) {
 @OrientationPreviews
 @Composable
 private fun ProfileLoggedInPreview() {
+    val chefService = MockChefService
+    val recipeService = MockRecipeService
+    val profileViewModel = ProfileViewModel(
+        chefRepository = ChefRepository(chefService),
+        recipeRepository = RecipeRepository(recipeService)
+    )
+    profileViewModel.chef = chefService.chef
+
     EZRecipesTheme {
         Surface {
-            ProfileLoggedIn(MockChefService.chef)
+            ProfileLoggedIn(chefService.chef, profileViewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -1,0 +1,98 @@
+package com.abhiek.ezrecipes.ui.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.chef.MockChefService
+import com.abhiek.ezrecipes.data.models.Chef
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+
+@Composable
+fun ProfileLoggedIn(chef: Chef) {
+    Column {
+        Text(
+            text = stringResource(R.string.profile_header, chef.email),
+            style = MaterialTheme.typography.titleLarge
+        )
+
+        Text(
+            text = stringResource(R.string.profile_favorites),
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Bold
+            )
+        )
+        Row {
+            for (id in chef.favoriteRecipes) {
+                Text(id)
+            }
+        }
+        HorizontalDivider()
+
+        Text(
+            text = stringResource(R.string.profile_recently_viewed),
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Bold
+            )
+        )
+        Row {
+            for ((id, timestamp) in chef.recentRecipes.entries) {
+                Text("$id: Recently viewed at $timestamp")
+            }
+        }
+        HorizontalDivider()
+
+        Text(
+            text = stringResource(R.string.profile_ratings),
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Bold
+            )
+        )
+        Row {
+            for ((id, rating) in chef.ratings.entries) {
+                Text("$id: $rating star(s)")
+            }
+        }
+
+        Button(
+            onClick = { println("Logout") }
+        ) {
+            Text(text = stringResource(R.string.logout))
+        }
+        Button(
+            onClick = { println("Change Email") }
+        ) {
+            Text(text = stringResource(R.string.change_email))
+        }
+        Button(
+            onClick = { println("Change Password") }
+        ) {
+            Text(text = stringResource(R.string.change_password))
+        }
+        Button(
+            onClick = { println("Delete Account") }
+        ) {
+            Text(text = stringResource(R.string.delete_account))
+        }
+    }
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun ProfileLoggedInPreview() {
+    EZRecipesTheme {
+        Surface {
+            ProfileLoggedIn(MockChefService.chef)
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -131,7 +131,10 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
             ),
             modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
-            Text(text = stringResource(R.string.delete_account))
+            Text(
+                text = stringResource(R.string.delete_account),
+                color = MaterialTheme.colorScheme.onError
+            )
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -26,8 +27,10 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
 fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
-    // Start loading all the recipe cards
-    profileViewModel.getAllChefRecipes()
+    LaunchedEffect(Unit) {
+        // Start loading all the recipe cards
+        profileViewModel.getAllChefRecipes()
+    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedOut.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedOut.kt
@@ -1,11 +1,17 @@
 package com.abhiek.ezrecipes.ui.profile
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
@@ -15,13 +21,18 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 
 @Composable
 fun ProfileLoggedOut() {
-    Column {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.padding(8.dp)
+    ) {
         Text(
-            text = stringResource(R.string.login_message)
+            text = stringResource(R.string.login_message),
+            style = MaterialTheme.typography.headlineSmall
         )
 
         Button(
-            onClick = { println("Login") }
+            onClick = { println("Login") },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
             Text(text = stringResource(R.string.login))
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedOut.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedOut.kt
@@ -1,0 +1,42 @@
+package com.abhiek.ezrecipes.ui.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+
+@Composable
+fun ProfileLoggedOut() {
+    Column {
+        Text(
+            text = stringResource(R.string.login_message)
+        )
+
+        Button(
+            onClick = { println("Login") }
+        ) {
+            Text(text = stringResource(R.string.login))
+        }
+    }
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun ProfileLoggedOutPreview() {
+    EZRecipesTheme {
+        Surface {
+            ProfileLoggedOut()
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -4,17 +4,93 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.models.AuthState
 import com.abhiek.ezrecipes.data.models.Chef
+import com.abhiek.ezrecipes.data.models.Recipe
+import com.abhiek.ezrecipes.data.recipe.RecipeRepository
+import com.abhiek.ezrecipes.data.recipe.RecipeResult
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 class ProfileViewModel(
-    private val chefRepository: ChefRepository
+    private val chefRepository: ChefRepository,
+    private val recipeRepository: RecipeRepository
 ): ViewModel() {
+    var job by mutableStateOf<Job?>(null)
+        private set
+
     var authState by mutableStateOf(AuthState.UNAUTHENTICATED)
+    var isLoading by mutableStateOf(false)
     var chef by mutableStateOf<Chef?>(null)
+    var favoriteRecipes by mutableStateOf<List<Recipe>>(listOf())
+    var recentRecipes by mutableStateOf<List<Recipe>>(listOf())
+    var ratedRecipes by mutableStateOf<List<Recipe>>(listOf())
 
     companion object {
         private const val TAG = "ProfileViewModel"
+    }
+
+//    fun getRecipeById(id: Int) {
+//        job = viewModelScope.launch {
+//            isLoading = true
+//            val result = recipeRepository.getRecipeById(id)
+//            isLoading = false
+//
+//            when (result) {
+//                is RecipeResult.Success -> {
+//                    recipe = result.response
+//                    recipeError = null
+//                }
+//                is RecipeResult.Error -> {
+//                    recipe = null
+//                    recipeError = result.recipeError
+//                }
+//            }
+//        }
+//    }
+
+    fun getAllChefRecipes() {
+        if (chef == null) return
+
+        for (id in chef!!.favoriteRecipes) {
+            id.toIntOrNull()?.let { recipeId ->
+                viewModelScope.launch {
+                    val result = recipeRepository.getRecipeById(recipeId)
+
+                    if (result is RecipeResult.Success) {
+                        favoriteRecipes += result.response
+                    }
+                }
+                //getRecipeById(recipeId)
+            }
+        }
+
+        for ((id, timestamp) in chef!!.recentRecipes.entries) {
+            id.toIntOrNull()?.let { recipeId ->
+                viewModelScope.launch {
+                    val result = recipeRepository.getRecipeById(recipeId)
+
+                    if (result is RecipeResult.Success) {
+                        recentRecipes += result.response
+                    }
+                }
+                //getRecipeById(recipeId)
+            }
+        }
+
+        for ((id, rating) in chef!!.ratings.entries) {
+            id.toIntOrNull()?.let { recipeId ->
+                viewModelScope.launch {
+                    val result = recipeRepository.getRecipeById(recipeId)
+
+                    if (result is RecipeResult.Success) {
+                        ratedRecipes += result.response
+                    }
+                }
+                //getRecipeById(recipeId)
+            }
+        }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -1,0 +1,18 @@
+package com.abhiek.ezrecipes.ui.profile
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.abhiek.ezrecipes.data.models.AuthState
+import com.abhiek.ezrecipes.data.models.Profile
+
+class ProfileViewModel: ViewModel() {
+    var authState by mutableStateOf(AuthState.UNAUTHENTICATED)
+    var profile by mutableStateOf<Profile?>(null)
+        private set
+
+    companion object {
+        private const val TAG = "ProfileViewModel"
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -4,13 +4,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.models.AuthState
-import com.abhiek.ezrecipes.data.models.Profile
+import com.abhiek.ezrecipes.data.models.Chef
 
-class ProfileViewModel: ViewModel() {
+class ProfileViewModel(
+    private val chefRepository: ChefRepository
+): ViewModel() {
     var authState by mutableStateOf(AuthState.UNAUTHENTICATED)
-    var profile by mutableStateOf<Profile?>(null)
-        private set
+    var chef by mutableStateOf<Chef?>(null)
 
     companion object {
         private const val TAG = "ProfileViewModel"

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
@@ -1,14 +1,19 @@
 package com.abhiek.ezrecipes.ui.profile
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.abhiek.ezrecipes.data.chef.ChefRepository
+import com.abhiek.ezrecipes.data.chef.ChefService
 
-class ProfileViewModelFactory(private val context: Context): ViewModelProvider.Factory {
+class ProfileViewModelFactory: ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
-            return ProfileViewModel() as T
+            return ProfileViewModel(
+                chefRepository = ChefRepository(
+                    chefService = ChefService.instance
+                )
+            ) as T
         }
 
         throw IllegalArgumentException("Unknown ViewModel class")

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.abhiek.ezrecipes.ui.profile
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class ProfileViewModelFactory(private val context: Context): ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
+            return ProfileViewModel() as T
+        }
+
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.ChefService
+import com.abhiek.ezrecipes.data.recipe.RecipeRepository
+import com.abhiek.ezrecipes.data.recipe.RecipeService
 
 class ProfileViewModelFactory: ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
@@ -12,6 +14,9 @@ class ProfileViewModelFactory: ViewModelProvider.Factory {
             return ProfileViewModel(
                 chefRepository = ChefRepository(
                     chefService = ChefService.instance
+                ),
+                recipeRepository = RecipeRepository(
+                    recipeService = RecipeService.instance
                 )
             ) as T
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/SkeletonLoader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/SkeletonLoader.kt
@@ -1,0 +1,109 @@
+package com.abhiek.ezrecipes.ui.profile
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+
+// Source: https://stackoverflow.com/a/78910106
+@Composable
+fun SkeletonLoader(
+    modifier: Modifier = Modifier,
+    isVisible: Boolean = true,
+    content: @Composable BoxScope.() -> Unit
+) {
+    val shimmerColors = listOf(
+        Color.LightGray.copy(alpha = 0.6f),
+        Color.LightGray.copy(alpha = 0.2f),
+        Color.LightGray.copy(alpha = 0.6f)
+    )
+
+    val transition = rememberInfiniteTransition(label = "")
+    val translateAnim by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1700, delayMillis = 200),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = ""
+    )
+
+    val brush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset.Zero,
+        end = Offset(x = translateAnim, y = translateAnim)
+    )
+
+
+    if (isVisible) {
+        Box(modifier = modifier.background(brush)) {
+            Box(modifier = Modifier
+                .matchParentSize()
+                .graphicsLayer { alpha = 1f })
+        }
+    } else {
+        Box(modifier = modifier) {
+            content()
+        }
+
+    }
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun SkeletonLoaderPreview() {
+    EZRecipesTheme {
+        Surface {
+            Row {
+                SkeletonLoader(
+                    modifier = Modifier
+                        .height(100.dp)
+                        .padding(4.dp)
+                        .weight(0.3f)
+                        .clip(RoundedCornerShape(4.dp)),
+                    isVisible = true
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_launcher_background),
+                        contentDescription = ""
+                    )
+                }
+                SkeletonLoader(
+                    modifier = Modifier
+                        .height(100.dp)
+                        .padding(4.dp)
+                        .weight(0.7f)
+                        .clip(RoundedCornerShape(4.dp)),
+                    isVisible = true
+                ) {
+                    Text(
+                        text = "Content to display after content has loaded"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -31,6 +31,7 @@ object Constants {
         const val SEARCH = "search"
         const val RESULTS = "search/results"
         const val GLOSSARY = "glossary"
+        const val PROFILE = "profile"
     }
 
     object Room {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -9,6 +9,7 @@ object Constants {
     const val SERVER_BASE_URL = "https://ez-recipes-server.onrender.com"
     const val RECIPE_PATH = "/api/recipes/"
     const val TERMS_PATH = "/api/terms/"
+    const val CHEFS_PATH = "/api/chefs/"
     const val TIMEOUT_SECONDS = 60L
 
     const val RECIPE_WEB_ORIGIN = "https://ez-recipes-web.onrender.com"
@@ -534,6 +535,20 @@ object Constants {
                 word = "al dente",
                 definition = "(\"to the tooth\") pasta or rice that's cooked so it can be chewed"
             )
+        )
+        val CHEF = Chef(
+            uid = "oJG5PZ8KIIfvQMDsQzOwDbu2m6O2",
+            email = "test@email.com",
+            ratings = mapOf(
+                "641024" to 5,
+                "663849" to 3
+            ),
+            recentRecipes = mapOf(
+                "641024" to "2024-10-17T02:54:07.471+00:00",
+                "663849" to "2024-10-17T22:28:27.387+00:00"
+            ),
+            favoriteRecipes = listOf("641024"),
+            token = "e30.e30.e30"
         )
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Constants.kt
@@ -1,7 +1,5 @@
 package com.abhiek.ezrecipes.utils
 
-import android.content.res.Resources
-import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.models.*
 
 object Constants {
@@ -15,7 +13,8 @@ object Constants {
     const val RECIPE_WEB_ORIGIN = "https://ez-recipes-web.onrender.com"
 
     // Error message to fallback on in case all fails
-    val UNKNOWN_ERROR = Resources.getSystem().getString(R.string.unknown_error)
+    const val UNKNOWN_ERROR = "Something went terribly wrong. Please submit a bug report to " +
+            "https://github.com/Abhiek187/ez-recipes-android/issues"
 
     const val MIN_CALS = 0
     const val MAX_CALS = 2000
@@ -24,16 +23,10 @@ object Constants {
     const val MAX_RECENT_RECIPES = 10
     const val RECIPES_TO_PRESENT_REVIEW = 5
 
-    object Routes {
-        // tabs = user-facing labels, routes = internal "pretend" URL paths
-        // All tabs have routes, but not all routes have tabs
-        const val HOME = "home"
-        const val RECIPE = "recipe/{id}"
-        const val SEARCH = "search"
-        const val RESULTS = "search/results"
-        const val GLOSSARY = "glossary"
-        const val PROFILE = "profile"
-    }
+    /* Using sealedSubclasses requires reflection, which will make the app slower,
+     * so list each tab manually
+     */
+    val TABS = listOf(Tab.Home, Tab.Search, Tab.Glossary, Tab.Profile)
 
     object Room {
         const val DATABASE_NAME = "AppDatabase"

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Routes.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Routes.kt
@@ -1,0 +1,12 @@
+package com.abhiek.ezrecipes.utils
+
+object Routes {
+    // tabs = user-facing labels, routes = internal "pretend" URL paths
+    // All tabs have routes, but not all routes have tabs
+    const val HOME = "home"
+    const val RECIPE = "recipe/{id}"
+    const val SEARCH = "search"
+    const val RESULTS = "search/results"
+    const val GLOSSARY = "glossary"
+    const val PROFILE = "profile"
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Tab.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/Tab.kt
@@ -1,4 +1,4 @@
-package com.abhiek.ezrecipes.ui.navbar
+package com.abhiek.ezrecipes.utils
 
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
@@ -8,15 +8,14 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.abhiek.ezrecipes.R
-import com.abhiek.ezrecipes.utils.Constants
 
 // Routes and their associated titles and icons in the navigation graph
 sealed class Tab(val route: String, @StringRes val resourceId: Int, val icon: ImageVector) {
     // Icons: https://fonts.google.com/icons (some require material-icons-extended)
-    data object Home: Tab(Constants.Routes.HOME, R.string.home_tab, Icons.Filled.Home)
-    data object Search: Tab(Constants.Routes.SEARCH, R.string.search_tab, Icons.Filled.Search)
-    data object Glossary: Tab(Constants.Routes.GLOSSARY, R.string.glossary_tab,
+    data object Home: Tab(Routes.HOME, R.string.home_tab, Icons.Filled.Home)
+    data object Search: Tab(Routes.SEARCH, R.string.search_tab, Icons.Filled.Search)
+    data object Glossary: Tab(Routes.GLOSSARY, R.string.glossary_tab,
         Icons.AutoMirrored.Filled.MenuBook)
-    data object Profile: Tab(Constants.Routes.PROFILE, R.string.profile_tab,
+    data object Profile: Tab(Routes.PROFILE, R.string.profile_tab,
         Icons.Filled.AccountCircle)
 }

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -116,10 +116,10 @@
     <string name="profile_recently_viewed">Recently Viewed</string>
     <string name="profile_ratings">Ratings</string>
     <string name="login_message">
-        Signing up for an account is free and gives you great perks, including:
-        - Saving your favorite recipes
-        - Saving more than 10 recently viewed recipes
-        - Rating recipes
+        Signing up for an account is free and gives you great perks, including:\n
+        - Saving your favorite recipes\n
+        - Saving more than 10 recently viewed recipes\n
+        - Rating recipes\n
         - Syncing recipes across the web and mobile apps
     </string>
     <string name="login">Login</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="home_tab">Home</string>
     <string name="search_tab">Search</string>
     <string name="glossary_tab">Glossary</string>
+    <string name="profile_tab">Profile</string>
 
     <!-- Home Screen -->
     <string name="find_recipe_button">Find Me a Recipe!</string>
@@ -108,4 +109,22 @@
 
     <string name="results_title">Results</string>
     <string name="results_placeholder">Use the filters to search for your favorite recipes!</string>
+
+    <!-- Profile Screen -->
+    <string name="profile_header">Chef %1$s</string>
+    <string name="profile_favorites">Favorites</string>
+    <string name="profile_recently_viewed">Recently Viewed</string>
+    <string name="profile_ratings">Ratings</string>
+    <string name="login_message">
+        Signing up for an account is free and gives you great perks, including:
+        - Saving your favorite recipes
+        - Saving more than 10 recently viewed recipes
+        - Rating recipes
+        - Syncing recipes across the web and mobile apps
+    </string>
+    <string name="login">Login</string>
+    <string name="logout">Logout</string>
+    <string name="change_email">Change Email</string>
+    <string name="change_password">Change Password</string>
+    <string name="delete_account">Delete Account</string>
 </resources>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -112,9 +112,9 @@
 
     <!-- Profile Screen -->
     <string name="profile_header">Chef %1$s</string>
-    <string name="profile_favorites">Favorites</string>
-    <string name="profile_recently_viewed">Recently Viewed</string>
-    <string name="profile_ratings">Ratings</string>
+    <string name="profile_favorites">💖 Favorites</string>
+    <string name="profile_recently_viewed">⌚ Recently Viewed</string>
+    <string name="profile_ratings">⭐ Ratings</string>
     <string name="login_message">
         Signing up for an account is free and gives you great perks, including:\n
         &#8226; Saving your favorite recipes\n

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -117,10 +117,10 @@
     <string name="profile_ratings">Ratings</string>
     <string name="login_message">
         Signing up for an account is free and gives you great perks, including:\n
-        - Saving your favorite recipes\n
-        - Saving more than 10 recently viewed recipes\n
-        - Rating recipes\n
-        - Syncing recipes across the web and mobile apps
+        &#8226; Saving your favorite recipes\n
+        &#8226; Saving more than 10 recently viewed recipes\n
+        &#8226; Rating recipes\n
+        &#8226; Syncing recipes across the web and mobile apps
     </string>
     <string name="login">Login</string>
     <string name="logout">Logout</string>

--- a/EZRecipes/build.gradle.kts
+++ b/EZRecipes/build.gradle.kts
@@ -1,9 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    val kotlinVersion = "1.9.22"
+    // Kotlin versions: https://kotlinlang.org/docs/releases.html#release-details
+    val kotlinVersion = "2.0.21"
 
     id("com.android.application") version "8.7.1" apply false
     id("org.jetbrains.kotlin.android") version kotlinVersion apply false
     // Version must match Kotlin: https://github.com/google/ksp/releases
-    id("com.google.devtools.ksp") version "$kotlinVersion-1.0.17" apply false
+    id("com.google.devtools.ksp") version "$kotlinVersion-1.0.26" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version kotlinVersion apply false
 }

--- a/EZRecipes/build.gradle.kts
+++ b/EZRecipes/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     // Kotlin versions: https://kotlinlang.org/docs/releases.html#release-details
     val kotlinVersion = "2.0.21"
 
-    id("com.android.application") version "8.7.1" apply false
+    id("com.android.application") version "8.7.2" apply false
     id("org.jetbrains.kotlin.android") version kotlinVersion apply false
     // Version must match Kotlin: https://github.com/google/ksp/releases
     id("com.google.devtools.ksp") version "$kotlinVersion-1.0.26" apply false


### PR DESCRIPTION
| Logged In | Logged Out |
| - | - |
| ![image](https://github.com/user-attachments/assets/ad153ae0-bffb-4fc3-85f3-ed506b782a0d) | ![image](https://github.com/user-attachments/assets/0279f4a7-74a5-4165-986c-a047b5780b58) |

_Partial implementation of https://github.com/Abhiek187/ez-recipes-web/issues/312_ (Pardon the previews, the system bars have started overlapping now that edge-to-edge is enabled. It'll be easier to take screenshots from the device once the basic login logic is implemented.)

This PR is big and took longer than expected, so I'll cut to the chase. I created a new tab to show the chef's profile depending on if they're logged in or not. I added all the Retrofit methods for all the new server APIs, but haven't integrated any of them yet. Those tests will come once those integrations begin.

But in the meantime, I was focused on getting the UI ready. It's not 100% yet. I might adjust the buttons to account for larger screens. The main thing is that I need more time to figure out how to handle all the recipe cards for the favorites, recent, and rated recipes. As I was working on this, I realized I could add some cool UI components like an accordion or a skeleton loader to handle loading and presenting all the recipe cards. But that was more manual work since these are not built into Material Design. Then I need to configure the ViewModel to load each recipe in parallel. Also, I might want to adjust what the recipe card shows depending on the category. For example, in ratings, I should show what the recipe rated each recipe (or even just the average rating). I may also want to sort the recipes by time or rating in these sections.

...So yeah there's more UI work than I anticipated. And that's before I have to integrate all the API calls and do token management beyond just logging in/logging out. 🤷 Good thing I'm not under a strict deadline!