### PR TITLE
Feature/login

### DIFF
--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefRepository.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefRepository.kt
@@ -8,9 +8,11 @@ import retrofit2.Response
 
 class ChefRepository(private val chefService: ChefService) {
     private fun <T> parseResponse(response: Response<T>): ChefResult<T> {
-        // isSuccessful means a 2xx response code
-        return if (response.isSuccessful && response.body() != null) {
-            ChefResult.Success(response.body()!!)
+        // Empty bodies are ok as long as a 2xx response is returned
+        return if (response.isSuccessful) {
+            // Unit:Kotlin::Void:Java
+            @Suppress("UNCHECKED_CAST")
+            ChefResult.Success(response.body() ?: Unit as T)
         } else {
             val errorString = response.errorBody()?.string()
 
@@ -56,7 +58,7 @@ class ChefRepository(private val chefService: ChefService) {
         }
     }
 
-    suspend fun deleteChef(token: String): ChefResult<String> {
+    suspend fun deleteChef(token: String): ChefResult<Void> {
         return try {
             val response = chefService.deleteChef(token)
             parseResponse(response)
@@ -86,7 +88,7 @@ class ChefRepository(private val chefService: ChefService) {
         }
     }
 
-    suspend fun logout(token: String): ChefResult<String> {
+    suspend fun logout(token: String): ChefResult<Void> {
         return try {
             val response = chefService.logout(token)
             parseResponse(response)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefService.kt
@@ -29,7 +29,7 @@ interface ChefService {
     @DELETE(".")
     suspend fun deleteChef(
         @Header("Authorization") token: String
-    ): Response<String> // empty response
+    ): Response<Void> // empty response
 
     @POST("verify")
     suspend fun verifyEmail(
@@ -44,7 +44,7 @@ interface ChefService {
     @POST("logout")
     suspend fun logout(
         @Header("Authorization") token: String
-    ): Response<String>
+    ): Response<Void>
 
     companion object {
         private lateinit var chefService: ChefService

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/MockChefService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/MockChefService.kt
@@ -7,11 +7,13 @@ import retrofit2.Response
 
 object MockChefService: ChefService {
     var isSuccess = true
+    var isEmailVerified = true
+
     val chef = Constants.Mocks.CHEF
     val loginResponse = LoginResponse(
         uid = chef.uid,
         token = chef.token,
-        emailVerified = true
+        emailVerified = isEmailVerified
     )
     val chefEmailResponse = ChefEmailResponse(
         kind = "identitytoolkit#GetOobConfirmationCodeResponse",

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/MockChefService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/MockChefService.kt
@@ -53,9 +53,9 @@ object MockChefService: ChefService {
         }
     }
 
-    override suspend fun deleteChef(token: String): Response<String> {
+    override suspend fun deleteChef(token: String): Response<Void> {
         return if (isSuccess) {
-            Response.success("")
+            Response.success(null)
         } else {
             Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
         }
@@ -77,9 +77,9 @@ object MockChefService: ChefService {
         }
     }
 
-    override suspend fun logout(token: String): Response<String> {
+    override suspend fun logout(token: String): Response<Void> {
         return if (isSuccess) {
-            Response.success("")
+            Response.success(null)
         } else {
             Response.error(401, TOKEN_ERROR_STRING.toResponseBody())
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
@@ -31,8 +31,8 @@ fun LoginDialog(profileViewModel: ProfileViewModel, onDismiss: () -> Unit) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(
-            usePlatformDefaultWidth = false, // Occupy full screen width
-            decorFitsSystemWindows = false // Allow custom layout around system bars
+            usePlatformDefaultWidth = false, // occupy full screen width
+            decorFitsSystemWindows = false // allow custom layout around system bars
         )
     ) {
         // Add a background so the dialog appears on top of the main content

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
@@ -121,6 +121,9 @@ fun LoginDialog(profileViewModel: ProfileViewModel, onDismiss: () -> Unit) {
                         email = backStackEntry.arguments?.getString("email"),
                         onResend = {
                             profileViewModel.sendVerificationEmail()
+                        },
+                        onLogout = {
+                            profileViewModel.logout()
                         }
                     )
                 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
@@ -46,7 +46,47 @@ fun LoginDialog(profileViewModel: ProfileViewModel, onDismiss: () -> Unit) {
             val navController = rememberNavController()
 
             NavHost(navController = navController, startDestination = Routes.LOGIN) {
-                composable(Routes.LOGIN) { LoginForm(navController) }
+                composable(Routes.LOGIN) {
+                    LoginForm(
+                        profileViewModel = profileViewModel,
+                        onSignup = {
+                            navController.navigate(Routes.SIGN_UP) {
+                                // Close the modal whenever the user navigates back
+                                popUpTo(
+                                    navController.currentBackStackEntry?.destination?.route
+                                        ?: return@navigate
+                                ) {
+                                    inclusive =  true
+                                }
+                                launchSingleTop = true
+                            }
+                        },
+                        onForgotPassword = {
+                            navController.navigate(Routes.FORGOT_PASSWORD) {
+                                popUpTo(
+                                    navController.currentBackStackEntry?.destination?.route
+                                        ?: return@navigate
+                                ) {
+                                    inclusive =  true
+                                }
+                                launchSingleTop = true
+                            }
+                        },
+                        onVerifyEmail = { email ->
+                            navController.navigate(
+                                Routes.VERIFY_EMAIL.replace("{email}", email)
+                            ) {
+                                popUpTo(
+                                    navController.currentBackStackEntry?.destination?.route
+                                        ?: return@navigate
+                                ) {
+                                    inclusive =  true
+                                }
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                }
                 composable(Routes.SIGN_UP) {
                     SignUpForm(
                         profileViewModel = profileViewModel,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
@@ -96,7 +96,7 @@ fun LoginForm(
                 Text(stringResource(R.string.username_field))
             },
             supportingText = {
-                if (usernameEmpty) {
+                if (usernameTouched && usernameEmpty) {
                     Text(stringResource(R.string.field_required, "Username"))
                 }
             },
@@ -132,7 +132,7 @@ fun LoginForm(
                 }
             },
             supportingText = {
-                if (passwordEmpty) {
+                if (passwordTouched && passwordEmpty) {
                     Text(stringResource(R.string.field_required, "Password"))
                 }
             },

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
@@ -1,6 +1,5 @@
 package com.abhiek.ezrecipes.ui.login
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,34 +12,54 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.input.*
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.chef.ChefRepository
+import com.abhiek.ezrecipes.data.chef.MockChefService
+import com.abhiek.ezrecipes.data.recipe.MockRecipeService
+import com.abhiek.ezrecipes.data.recipe.RecipeRepository
+import com.abhiek.ezrecipes.data.storage.DataStoreService
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.profile.ProfileViewModel
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
-import com.abhiek.ezrecipes.utils.Routes
+import com.abhiek.ezrecipes.ui.util.ErrorAlert
 
 @Composable
-fun LoginForm(navController: NavController) {
+fun LoginForm(
+    profileViewModel: ProfileViewModel,
+    onSignup: () -> Unit,
+    onForgotPassword: () -> Unit,
+    onVerifyEmail: (email: String) -> Unit
+) {
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var showPassword by remember { mutableStateOf(false) }
+
+    // Focus
+    var usernameTouched by remember { mutableStateOf(false) }
+    var passwordTouched by remember { mutableStateOf(false) }
 
     // Errors
     val usernameEmpty = username.isEmpty()
     val passwordEmpty = password.isEmpty()
 
-    val context = LocalContext.current
+    LaunchedEffect(profileViewModel.chef) {
+        // Check if the user signed up, but didn't verify their email yet
+        if (profileViewModel.chef?.emailVerified == false) {
+            profileViewModel.sendVerificationEmail()
+            onVerifyEmail(username)
+        }
+    }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -59,16 +78,7 @@ fun LoginForm(navController: NavController) {
             )
             TextButton(
                 onClick = {
-                    navController.navigate(Routes.SIGN_UP) {
-                        // Close the modal whenever the user navigates back
-                        popUpTo(
-                            navController.currentBackStackEntry?.destination?.route
-                                ?: return@navigate
-                        ) {
-                            inclusive =  true
-                        }
-                        launchSingleTop = true
-                    }
+                    onSignup()
                 }
             ) {
                 Text(
@@ -90,11 +100,16 @@ fun LoginForm(navController: NavController) {
                     Text(stringResource(R.string.field_required, "Username"))
                 }
             },
-            isError = usernameEmpty,
+            isError = usernameTouched && usernameEmpty,
             keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
                 keyboardType = KeyboardType.Email,
                 imeAction = ImeAction.Next
-            )
+            ),
+            modifier = Modifier.onFocusChanged {
+                if (it.isFocused) usernameTouched = true
+            }
         )
         TextField(
             value = password,
@@ -121,25 +136,22 @@ fun LoginForm(navController: NavController) {
                     Text(stringResource(R.string.field_required, "Password"))
                 }
             },
-            isError = passwordEmpty,
+            isError = passwordTouched && passwordEmpty,
             visualTransformation = if (showPassword) VisualTransformation.None
                 else PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
                 keyboardType = KeyboardType.Password,
                 imeAction = ImeAction.Done
-            )
+            ),
+            modifier = Modifier.onFocusChanged {
+                if (it.isFocused) passwordTouched = true
+            }
         )
         TextButton(
             onClick = {
-                navController.navigate(Routes.FORGOT_PASSWORD) {
-                    popUpTo(
-                        navController.currentBackStackEntry?.destination?.route
-                            ?: return@navigate
-                    ) {
-                        inclusive =  true
-                    }
-                    launchSingleTop = true
-                }
+                onForgotPassword()
             }
         ) {
             Text(
@@ -147,20 +159,46 @@ fun LoginForm(navController: NavController) {
                 style = MaterialTheme.typography.titleLarge
             )
         }
-        Button(
-            onClick = {
-                Toast.makeText(
-                    context,
-                    "Username: $username, Password: $password",
-                    Toast.LENGTH_SHORT
-                ).show()
-            },
-            enabled = !usernameEmpty && !passwordEmpty,
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.align(Alignment.End)
         ) {
-            Text(stringResource(R.string.login))
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .alpha(if (profileViewModel.isLoading) 1f else 0f)
+            )
+            Button(
+                onClick = {
+                    profileViewModel.login(username, password)
+                },
+                enabled = !usernameEmpty && !passwordEmpty && !profileViewModel.isLoading
+            ) {
+                Text(stringResource(R.string.login))
+            }
+        }
+        if (profileViewModel.showAlert) {
+            ErrorAlert(
+                message = profileViewModel.recipeError?.error,
+                onDismiss = {
+                    profileViewModel.showAlert = false
+                }
+            )
         }
     }
+}
+
+private data class LoginFormState(
+    val isLoading: Boolean,
+    val showAlert: Boolean
+)
+
+private class LoginFormPreviewParameterProvider: PreviewParameterProvider<LoginFormState> {
+    override val values = sequenceOf(
+        LoginFormState(isLoading = false, showAlert = false),
+        LoginFormState(isLoading = true, showAlert = false),
+        LoginFormState(isLoading = false, showAlert = true)
+    )
 }
 
 @DevicePreviews
@@ -168,12 +206,24 @@ fun LoginForm(navController: NavController) {
 @FontPreviews
 @OrientationPreviews
 @Composable
-private fun LoginFormPreview() {
-    val navController = rememberNavController()
+private fun LoginFormPreview(
+    @PreviewParameter(LoginFormPreviewParameterProvider::class) state: LoginFormState
+) {
+    val context = LocalContext.current
+
+    val chefService = MockChefService
+    val recipeService = MockRecipeService
+    val profileViewModel = ProfileViewModel(
+        chefRepository = ChefRepository(chefService),
+        recipeRepository = RecipeRepository(recipeService),
+        dataStoreService = DataStoreService(context)
+    )
+    profileViewModel.isLoading = state.isLoading
+    profileViewModel.showAlert = state.showAlert
 
     EZRecipesTheme {
         Surface {
-            LoginForm(navController)
+            LoginForm(profileViewModel, {}, {}, {})
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
@@ -37,9 +37,9 @@ import com.abhiek.ezrecipes.ui.util.ErrorAlert
 @Composable
 fun LoginForm(
     profileViewModel: ProfileViewModel,
-    onSignup: () -> Unit,
-    onForgotPassword: () -> Unit,
-    onVerifyEmail: (email: String) -> Unit
+    onSignup: () -> Unit = {},
+    onForgotPassword: () -> Unit = {},
+    onVerifyEmail: (email: String) -> Unit = {}
 ) {
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -57,7 +57,7 @@ fun LoginForm(
         // Check if the user signed up, but didn't verify their email yet
         if (profileViewModel.chef?.emailVerified == false) {
             profileViewModel.sendVerificationEmail()
-            onVerifyEmail(username)
+            onVerifyEmail(profileViewModel.chef!!.email)
         }
     }
 
@@ -223,7 +223,7 @@ private fun LoginFormPreview(
 
     EZRecipesTheme {
         Surface {
-            LoginForm(profileViewModel, {}, {}, {})
+            LoginForm(profileViewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
@@ -39,8 +39,8 @@ import com.abhiek.ezrecipes.utils.Constants
 @Composable
 fun SignUpForm(
     profileViewModel: ProfileViewModel,
-    onLogin: () -> Unit,
-    onVerifyEmail: (email: String) -> Unit
+    onLogin: () -> Unit = {},
+    onVerifyEmail: (email: String) -> Unit = {}
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -263,7 +263,7 @@ private fun SignUpFormPreview(
 
     EZRecipesTheme {
         Surface {
-            SignUpForm(profileViewModel, {}, {})
+            SignUpForm(profileViewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
@@ -101,9 +101,9 @@ fun SignUpForm(
                 Text(stringResource(R.string.email_field))
             },
             supportingText = {
-                if (emailEmpty) {
+                if (emailTouched && emailEmpty) {
                     Text(stringResource(R.string.field_required, "Email"))
-                } else if (emailInvalid) {
+                } else if (emailTouched && emailInvalid) {
                     Text(stringResource(R.string.email_invalid))
                 }
             },
@@ -139,9 +139,9 @@ fun SignUpForm(
                 }
             },
             supportingText = {
-                if (passwordEmpty) {
+                if (passwordTouched && passwordEmpty) {
                     Text(stringResource(R.string.field_required, "Password"))
-                } else if (passwordTooShort) {
+                } else if (passwordTouched && passwordTooShort) {
                     Text(stringResource(R.string.password_min_length))
                 }
             },
@@ -179,7 +179,7 @@ fun SignUpForm(
                 }
             },
             supportingText = {
-                if (passwordsDoNotMatch) {
+                if (passwordConfirmTouched && passwordsDoNotMatch) {
                     Text(stringResource(R.string.password_match))
                 } else {
                     Text(stringResource(R.string.password_min_length))

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
@@ -17,10 +17,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.input.*
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -112,6 +109,8 @@ fun SignUpForm(
             },
             isError = emailTouched && (emailEmpty || emailInvalid),
             keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
                 keyboardType = KeyboardType.Email,
                 imeAction = ImeAction.Next
             ),
@@ -133,9 +132,9 @@ fun SignUpForm(
                 ) {
                     Icon(
                         imageVector = if (showPassword) Icons.Filled.Visibility
-                        else Icons.Filled.VisibilityOff,
+                            else Icons.Filled.VisibilityOff,
                         contentDescription = if (showPassword) "Hide password"
-                        else "Show password"
+                            else "Show password"
                     )
                 }
             },
@@ -148,8 +147,10 @@ fun SignUpForm(
             },
             isError = passwordTouched && (passwordEmpty || passwordTooShort),
             visualTransformation = if (showPassword) VisualTransformation.None
-            else PasswordVisualTransformation(),
+                else PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
                 keyboardType = KeyboardType.Password,
                 imeAction = ImeAction.Next
             ),
@@ -171,9 +172,9 @@ fun SignUpForm(
                 ) {
                     Icon(
                         imageVector = if (showPassword) Icons.Filled.Visibility
-                        else Icons.Filled.VisibilityOff,
+                            else Icons.Filled.VisibilityOff,
                         contentDescription = if (showPassword) "Hide password"
-                        else "Show password"
+                            else "Show password"
                     )
                 }
             },
@@ -186,8 +187,10 @@ fun SignUpForm(
             },
             isError = passwordConfirmTouched && passwordsDoNotMatch,
             visualTransformation = if (showPassword) VisualTransformation.None
-            else PasswordVisualTransformation(),
+                else PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.None,
+                autoCorrectEnabled = false,
                 keyboardType = KeyboardType.Password,
                 imeAction = ImeAction.Done
             ),
@@ -231,7 +234,6 @@ private data class SignUpFormState(
 )
 
 private class SignUpFormPreviewParameterProvider: PreviewParameterProvider<SignUpFormState> {
-    // Show previews of the default home screen, with the progress bar, and with an alert
     override val values = sequenceOf(
         SignUpFormState(isLoading = false, showAlert = false),
         SignUpFormState(isLoading = true, showAlert = false),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
@@ -1,9 +1,6 @@
 package com.abhiek.ezrecipes.ui.login
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.*
@@ -24,7 +21,11 @@ import kotlinx.coroutines.delay
 import java.util.Locale
 
 @Composable
-fun VerifyEmail(email: String? = null, onResend: () -> Unit = {}) {
+fun VerifyEmail(
+    email: String? = null,
+    onResend: () -> Unit = {},
+    onLogout: () -> Unit = {}
+) {
     // Throttle the number of times the user can resend the verification email to satisfy API limits
     var enableResend by remember { mutableStateOf(false) }
     var secondsRemaining by remember { mutableIntStateOf(Constants.EMAIL_COOLDOWN_SECONDS) }
@@ -55,42 +56,60 @@ fun VerifyEmail(email: String? = null, onResend: () -> Unit = {}) {
                     R.string.email_verify_body,
                     email ?: "your email address"
                 ),
-                startIndex = 114 // don't change the string and make me recount ;P
+                startIndex = 114, // don't change the string and make me recount ;P
+                endIndex = 114 + (email ?: "your email address").length
             ),
             style = MaterialTheme.typography.bodyLarge
         )
-        Row(
-            verticalAlignment = Alignment.CenterVertically
+        Column(
+            modifier = Modifier.fillMaxWidth()
         ) {
-            Text(
-                text = stringResource(R.string.email_verify_retry_text),
-                style = MaterialTheme.typography.bodyMedium
-            )
-            TextButton(
-                onClick = {
-                    onResend()
-                    enableResend = false
-                },
-                enabled = enableResend
+            Row(
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = stringResource(R.string.email_verify_retry_link),
+                    text = stringResource(R.string.email_verify_retry_text),
                     style = MaterialTheme.typography.bodyMedium
                 )
+                TextButton(
+                    onClick = {
+                        onResend()
+                        enableResend = false
+                    },
+                    enabled = enableResend
+                ) {
+                    Text(
+                        text = stringResource(R.string.email_verify_retry_link),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                if (!enableResend) {
+                    Icon(
+                        imageVector = Icons.Filled.Schedule,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 4.dp)
+                    )
+                    Text(
+                        text = String.format(
+                            Locale.getDefault(),
+                            "%02d:%02d",
+                            secondsRemaining / 60, secondsRemaining % 60
+                        ),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
             }
-            if (!enableResend) {
-                Icon(
-                    imageVector = Icons.Filled.Schedule,
-                    contentDescription = null,
-                    modifier = Modifier.padding(end = 4.dp)
-                )
+            Button(
+                onClick = {
+                    onLogout()
+                },
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(end = 8.dp)
+            ) {
                 Text(
-                    text = String.format(
-                        Locale.getDefault(),
-                        "%02d:%02d",
-                        secondsRemaining / 60, secondsRemaining % 60
-                    ),
-                    style = MaterialTheme.typography.bodyMedium
+                    text = stringResource(R.string.logout),
+                    style = MaterialTheme.typography.bodySmall
                 )
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
@@ -30,6 +30,9 @@ fun VerifyEmail(
     var enableResend by remember { mutableStateOf(false) }
     var secondsRemaining by remember { mutableIntStateOf(Constants.EMAIL_COOLDOWN_SECONDS) }
 
+    val emailText = email ?: "your email address"
+    val emailStartIndex = 114 // don't change the string and make me recount ;P
+
     LaunchedEffect(enableResend) {
         if (!enableResend) {
             secondsRemaining = Constants.EMAIL_COOLDOWN_SECONDS
@@ -54,10 +57,10 @@ fun VerifyEmail(
             text = boldAnnotatedString(
                 text = stringResource(
                     R.string.email_verify_body,
-                    email ?: "your email address"
+                    emailText
                 ),
-                startIndex = 114, // don't change the string and make me recount ;P
-                endIndex = 114 + (email ?: "your email address").length
+                startIndex = emailStartIndex,
+                endIndex = emailStartIndex + emailText.length
             ),
             style = MaterialTheme.typography.bodyLarge
         )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/previews/OrientationPreviews.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/previews/OrientationPreviews.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview(
     name = "Portrait",
     group = "Orientations",
-    device = Devices.PHONE,
+    device = "spec:width=411dp,height=891dp",
     showSystemUi = true
 )
 @Preview(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -1,17 +1,22 @@
 package com.abhiek.ezrecipes.ui.profile
 
 import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
@@ -67,11 +72,18 @@ fun Profile(profileViewModel: ProfileViewModel, deepLinkAction: String? = null) 
     } else if (authState == AuthState.UNAUTHENTICATED) {
         ProfileLoggedOut(profileViewModel)
     } else {
-        Box(
+        Column(
             modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
+            verticalArrangement = Arrangement.spacedBy(
+                space = 16.dp,
+                alignment = Alignment.CenterVertically
+            ),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             CircularProgressIndicator()
+            Text(
+                text = stringResource(R.string.profile_loading)
+            )
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -27,7 +27,7 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.search.RecipeCard
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.ui.util.Accordion
-import com.abhiek.ezrecipes.ui.util.SkeletonLoader
+import com.abhiek.ezrecipes.ui.util.ErrorAlert
 
 @Composable
 fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
@@ -123,7 +123,9 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
         }
 
         Button(
-            onClick = { println("Logout") },
+            onClick = {
+                profileViewModel.logout()
+            },
             modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
             Text(text = stringResource(R.string.logout))
@@ -150,6 +152,15 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
             Text(
                 text = stringResource(R.string.delete_account),
                 color = MaterialTheme.colorScheme.onError
+            )
+        }
+
+        if (profileViewModel.showAlert) {
+            ErrorAlert(
+                message = profileViewModel.recipeError?.error,
+                onDismiss = {
+                    profileViewModel.showAlert = false
+                }
             )
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
@@ -126,9 +128,20 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
             onClick = {
                 profileViewModel.logout()
             },
+            enabled = !profileViewModel.isLoading,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
-            Text(text = stringResource(R.string.logout))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = stringResource(R.string.logout))
+                if (profileViewModel.isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(30.dp)
+                    )
+                }
+            }
         }
         Button(
             onClick = { println("Change Email") },
@@ -166,12 +179,26 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
     }
 }
 
+private data class ProfileLoggedInState(
+    val isLoading: Boolean
+)
+
+private class ProfileLoggedInPreviewParameterProvider:
+    PreviewParameterProvider<ProfileLoggedInState> {
+    override val values = sequenceOf(
+        ProfileLoggedInState(isLoading = false),
+        ProfileLoggedInState(isLoading = true)
+    )
+}
+
 @DevicePreviews
 @DisplayPreviews
 @FontPreviews
 @OrientationPreviews
 @Composable
-private fun ProfileLoggedInPreview() {
+private fun ProfileLoggedInPreview(
+    @PreviewParameter(ProfileLoggedInPreviewParameterProvider::class) state: ProfileLoggedInState
+) {
     val context = LocalContext.current
 
     val chefService = MockChefService
@@ -182,6 +209,7 @@ private fun ProfileLoggedInPreview() {
         dataStoreService = DataStoreService(context)
     )
     profileViewModel.chef = chefService.chef
+    profileViewModel.isLoading = state.isLoading
 
     EZRecipesTheme {
         Surface {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -210,6 +210,34 @@ class ProfileViewModel(
         }
     }
 
+    fun logout() {
+        job = viewModelScope.launch {
+            isLoading = true
+            val token = getToken()
+            val result = if (token != null) {
+                chefRepository.logout(token)
+            } else {
+                ChefResult.Error(RecipeError(Constants.NO_TOKEN_FOUND))
+            }
+            isLoading = false
+
+            when (result) {
+                is ChefResult.Success -> {
+                    recipeError = null
+                    showAlert = false
+
+                    clearToken()
+                    chef = null
+                    authState = AuthState.UNAUTHENTICATED
+                }
+                is ChefResult.Error -> {
+                    recipeError = result.recipeError
+                    showAlert = token != null && job?.isCancelled == false
+                }
+            }
+        }
+    }
+
 //    fun getRecipeById(id: Int) {
 //        job = viewModelScope.launch {
 //            isLoading = true

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -217,7 +217,8 @@ class ProfileViewModel(
             val result = if (token != null) {
                 chefRepository.logout(token)
             } else {
-                ChefResult.Error(RecipeError(Constants.NO_TOKEN_FOUND))
+                // Assume the user should be signed out since there's no auth token
+                ChefResult.Success(null)
             }
             isLoading = false
 
@@ -232,7 +233,7 @@ class ProfileViewModel(
                 }
                 is ChefResult.Error -> {
                     recipeError = result.recipeError
-                    showAlert = token != null && job?.isCancelled == false
+                    showAlert = job?.isCancelled == false
                 }
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -230,6 +230,7 @@ class ProfileViewModel(
                     clearToken()
                     chef = null
                     authState = AuthState.UNAUTHENTICATED
+                    openLoginDialog = false
                 }
                 is ChefResult.Error -> {
                     recipeError = result.recipeError

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -151,7 +151,9 @@
     <string name="email_verify_header">You\'re Almost There!</string>
     <string name="email_verify_body">
         We just need to verify your email before you can put on the chef\'s hat.
-        Check your email for a magic link sent to %1$s
+        Check your email for a magic link sent to %1$s\n\n
+
+        ⚠️ We will delete accounts from our system if they\'re not verified within 1 week.
     </string>
     <string name="email_verify_retry_text">Didn\'t receive an email?</string>
     <string name="email_verify_retry_link">Resend</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="results_placeholder">Use the filters to search for your favorite recipes!</string>
 
     <!-- Profile Screen -->
+    <string name="profile_loading">Getting your profile ready… 🧑‍🍳</string>
     <string name="profile_header">Chef %1$s</string>
     <string name="profile_favorites">💖 Favorites</string>
     <string name="profile_recently_viewed">⌚ Recently Viewed</string>

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/chef/ChefRepositoryTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/data/chef/ChefRepositoryTest.kt
@@ -96,7 +96,7 @@ internal class ChefRepositoryTest {
         val response = chefRepository.deleteChef(mockToken)
 
         assertTrue(response is ChefResult.Success)
-        assertEquals((response as ChefResult.Success).response, "")
+        assertEquals((response as ChefResult.Success).response, Unit)
     }
 
     @Test
@@ -150,7 +150,7 @@ internal class ChefRepositoryTest {
         val response = chefRepository.logout(mockToken)
 
         assertTrue(response is ChefResult.Success)
-        assertEquals((response as ChefResult.Success).response, "")
+        assertEquals((response as ChefResult.Success).response, Unit)
     }
 
     @Test

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
@@ -296,4 +296,53 @@ internal class ProfileViewModelTest {
         assertNull(viewModel.chef)
         assertEquals(viewModel.recipeError, mockChefService.tokenError)
     }
+
+    @Test
+    fun logoutSuccess() = runTest {
+        // Given a valid token
+        // When logging out
+        viewModel.logout()
+
+        // Then the user is unauthenticated
+        assertNull(viewModel.recipeError)
+        assertFalse(viewModel.showAlert)
+        assertNull(viewModel.chef)
+        assertEquals(viewModel.authState, AuthState.UNAUTHENTICATED)
+
+        coVerify { mockDataStoreService.getToken() }
+        verify { Encryptor.decrypt(mockEncryptedToken) }
+        coVerify { mockDataStoreService.deleteToken() }
+    }
+
+    @Test
+    fun logoutError() = runTest {
+        // Given a valid token
+        // When logging out and an error occurs
+        mockChefService.isSuccess = false
+        viewModel.logout()
+
+        // Then an error is shown
+        assertEquals(viewModel.recipeError, mockChefService.tokenError)
+
+        coVerify { mockDataStoreService.getToken() }
+        verify { Encryptor.decrypt(mockEncryptedToken) }
+    }
+
+    @Test
+    fun logoutNoToken() = runTest {
+        // Given no token
+        coEvery { mockDataStoreService.getToken() } returns null
+
+        // When logging out
+        viewModel.logout()
+
+        // Then the user is unauthenticated
+        assertNull(viewModel.recipeError)
+        assertFalse(viewModel.showAlert)
+        assertNull(viewModel.chef)
+        assertEquals(viewModel.authState, AuthState.UNAUTHENTICATED)
+
+        coVerify { mockDataStoreService.getToken() }
+        coVerify { mockDataStoreService.deleteToken() }
+    }
 }

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
@@ -308,6 +308,7 @@ internal class ProfileViewModelTest {
         assertFalse(viewModel.showAlert)
         assertNull(viewModel.chef)
         assertEquals(viewModel.authState, AuthState.UNAUTHENTICATED)
+        assertFalse(viewModel.openLoginDialog)
 
         coVerify { mockDataStoreService.getToken() }
         verify { Encryptor.decrypt(mockEncryptedToken) }
@@ -341,6 +342,7 @@ internal class ProfileViewModelTest {
         assertFalse(viewModel.showAlert)
         assertNull(viewModel.chef)
         assertEquals(viewModel.authState, AuthState.UNAUTHENTICATED)
+        assertFalse(viewModel.openLoginDialog)
 
         coVerify { mockDataStoreService.getToken() }
         coVerify { mockDataStoreService.deleteToken() }

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
@@ -16,6 +16,7 @@ import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -75,6 +76,13 @@ internal class ProfileViewModelTest {
         mockEncryptor()
     }
 
+    @AfterEach
+    fun tearDown() {
+        // Revert back to the defaults
+        mockChefService.isSuccess = true
+        mockChefService.isEmailVerified = true
+    }
+
     @Test
     fun createAccountSuccess() = runTest {
         // Given the user's credentials
@@ -82,7 +90,6 @@ internal class ProfileViewModelTest {
         val password = "test1234"
 
         // When creating an account
-        mockChefService.isSuccess = true
         viewModel.createAccount(username, password)
 
         // Then a new chef should be created
@@ -121,7 +128,6 @@ internal class ProfileViewModelTest {
     fun sendVerificationEmailSuccess() = runTest {
         // Given a valid token
         // When sending a verification email
-        mockChefService.isSuccess = true
         viewModel.sendVerificationEmail()
 
         // Then the email should be sent
@@ -156,7 +162,6 @@ internal class ProfileViewModelTest {
         coEvery { mockDataStoreService.getToken() } returns null
 
         // When sending a verification email
-        mockChefService.isSuccess = true
         viewModel.sendVerificationEmail()
 
         // Then an error alert isn't shown
@@ -170,7 +175,6 @@ internal class ProfileViewModelTest {
     fun getChefSuccess() = runTest {
         // Given a valid token
         // When getting the chef's profile
-        mockChefService.isSuccess = true
         viewModel.getChef()
 
         // Then the chef is saved and the user is authenticated
@@ -210,7 +214,6 @@ internal class ProfileViewModelTest {
         coEvery { mockDataStoreService.getToken() } returns null
 
         // When getting the chef's profile
-        mockChefService.isSuccess = true
         viewModel.getChef()
 
         // Then the user is unauthenticated
@@ -221,5 +224,76 @@ internal class ProfileViewModelTest {
 
         coVerify { mockDataStoreService.getToken() }
         coVerify { mockDataStoreService.deleteToken() }
+    }
+
+    @Test
+    fun loginSuccess() = runTest {
+        // Given the user's credentials
+        val username = "test@example.com"
+        val password = "test1234"
+
+        // When logging in
+        viewModel.login(username, password)
+
+        // Then the user should be authenticated
+        assertNull(viewModel.recipeError)
+        assertFalse(viewModel.showAlert)
+        assertEquals(viewModel.chef, Chef(
+            uid = mockChefService.loginResponse.uid,
+            email = username,
+            emailVerified = mockChefService.loginResponse.emailVerified,
+            ratings = mapOf(),
+            recentRecipes = mapOf(),
+            favoriteRecipes = listOf(),
+            token = mockChefService.loginResponse.token
+        ))
+        assertEquals(viewModel.authState, AuthState.AUTHENTICATED)
+        assertFalse(viewModel.openLoginDialog)
+
+        verify { Encryptor.encrypt(mockChefService.loginResponse.token) }
+        coVerify { mockDataStoreService.saveToken(mockEncryptedToken) }
+    }
+
+    @Test
+    fun loginEmailNotVerified() = runTest {
+        // Given the user hasn't verified their email
+        val username = "test@example.com"
+        val password = "test1234"
+
+        // When logging in
+        mockChefService.isEmailVerified = false
+        viewModel.createAccount(username, password)
+
+        // Then a new chef should be created, but the user shouldn't be authenticated
+        assertNull(viewModel.recipeError)
+        assertFalse(viewModel.showAlert)
+        assertEquals(viewModel.chef, Chef(
+            uid = mockChefService.loginResponse.uid,
+            email = username,
+            emailVerified = mockChefService.loginResponse.emailVerified,
+            ratings = mapOf(),
+            recentRecipes = mapOf(),
+            favoriteRecipes = listOf(),
+            token = mockChefService.loginResponse.token
+        ))
+        assertNotEquals(viewModel.authState, AuthState.AUTHENTICATED)
+
+        verify { Encryptor.encrypt(mockChefService.loginResponse.token) }
+        coVerify { mockDataStoreService.saveToken(mockEncryptedToken) }
+    }
+
+    @Test
+    fun loginError() = runTest {
+        // Given the user's credentials
+        val username = "test@example.com"
+        val password = "test1234"
+
+        // When logging in and an error occurs
+        mockChefService.isSuccess = false
+        viewModel.createAccount(username, password)
+
+        // Then an error is shown
+        assertNull(viewModel.chef)
+        assertEquals(viewModel.recipeError, mockChefService.tokenError)
     }
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/d30014ba-0d4b-4537-bc5b-663dbaf9983c

_The Android implementation of https://github.com/Abhiek187/ez-recipes-web/issues/7_

The login flow is now working. We can now login and logout very quickly in the app, which will make account testing much easier going forward! We still check on login if the user's email is verified and prompt them before authenticating them. If the logout fails for any reason, I fallback to clearing the token from the DataStore so the user isn't stuck "signed in".

I polished the flow in several ways:
- Disabled autocorrect & autocapitalization when entering the email and password. (This is something I would've picked up on much sooner if I was testing on a real device.)
- Prevented the supporting text errors from appearing if the user didn't interact with the text fields yet
- Added a disclaimer on the verify email screen that unverified accounts will be removed after 1 week. I also added a logout button here in case the user entered the wrong email or wants to sign in with a different account. With the way the app works, if the token is valid, but the email isn't verified, the `LoginDialog` will automatically route to this verify email screen.
- Added loading text to the profile tab since it might take a minute to load during cold starts