### PR TITLE
Feature/favorite

### DIFF
--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
@@ -129,14 +129,6 @@ internal class EZRecipesInstrumentedTest {
         favoriteButton.assertExists()
         unFavoriteButton.assertDoesNotExist()
 
-        favoriteButton.performClick()
-        favoriteButton.assertDoesNotExist()
-        unFavoriteButton.assertExists()
-
-        unFavoriteButton.performClick()
-        favoriteButton.assertExists()
-        unFavoriteButton.assertDoesNotExist()
-
         // Check that the share button opens the Sharesheet
         val shareButton = composeTestRule
             .onNodeWithContentDescription(activity.getString(R.string.share_alt))

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefService.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/ChefService.kt
@@ -1,5 +1,7 @@
 package com.abhiek.ezrecipes.data.chef
 
+import com.abhiek.ezrecipes.data.interceptors.CacheInterceptor
+import com.abhiek.ezrecipes.data.interceptors.SecureHttpLoggingInterceptor
 import com.abhiek.ezrecipes.data.models.*
 import com.abhiek.ezrecipes.utils.Constants
 import okhttp3.OkHttpClient
@@ -49,13 +51,17 @@ interface ChefService {
     companion object {
         private lateinit var chefService: ChefService
 
-        val instance: ChefService
-            get() {
+        fun getInstance(
+            // Need to inject the cache interceptor to pass the context properly
+            cacheInterceptor: CacheInterceptor
+        ): ChefService {
                 if (Companion::chefService.isInitialized) return chefService
 
                 val loggingInterceptor = SecureHttpLoggingInterceptor()
                 val httpClient = OkHttpClient().newBuilder()
+                    .cache(cacheInterceptor.cache)
                     .addInterceptor(loggingInterceptor)
+                    .addInterceptor(cacheInterceptor)
                     .readTimeout(Constants.TIMEOUT_SECONDS, TimeUnit.SECONDS)
                     .connectTimeout(Constants.TIMEOUT_SECONDS, TimeUnit.SECONDS)
                     .build()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/interceptors/CacheInterceptor.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/interceptors/CacheInterceptor.kt
@@ -1,0 +1,41 @@
+package com.abhiek.ezrecipes.data.interceptors
+
+import android.content.Context
+import okhttp3.Cache
+import okhttp3.CacheControl
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.concurrent.TimeUnit
+
+/**
+ * An interceptor to cache network responses
+ *
+ * @param context The application context
+ * @param sizeInMB The max size of the cache in MB
+ * @param age The max time to store the cache
+ * @param units The units of the age
+ */
+class CacheInterceptor(
+    private val context: Context,
+    private val sizeInMB: Int,
+    private val age: Int,
+    private val units: TimeUnit
+): Interceptor {
+    private val sizeInBytes = sizeInMB * 1024 * 1024L
+    // Cache directory: /data/data/PACKAGE-NAME/cache (/data/user/0 == /data/data)
+    val cache = Cache(context.cacheDir, sizeInBytes)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+
+        val cacheControl = CacheControl.Builder()
+            .maxAge(age, units)
+            .build()
+
+        return response.newBuilder()
+            .removeHeader("Pragma")
+            .removeHeader("Cache-Control")
+            .header("Cache-Control", cacheControl.toString())
+            .build()
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/interceptors/SecureHttpLoggingInterceptor.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/interceptors/SecureHttpLoggingInterceptor.kt
@@ -1,4 +1,4 @@
-package com.abhiek.ezrecipes.data.chef
+package com.abhiek.ezrecipes.data.interceptors
 
 import android.util.Log
 import okhttp3.Headers

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
@@ -6,6 +6,6 @@ data class Chef(
     var emailVerified: Boolean,
     val ratings: Map<String, Int>,
     val recentRecipes: Map<String, String>,
-    var favoriteRecipes: List<String>,
+    val favoriteRecipes: List<String>,
     val token: String
 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
@@ -6,6 +6,6 @@ data class Chef(
     var emailVerified: Boolean,
     val ratings: Map<String, Int>,
     val recentRecipes: Map<String, String>,
-    val favoriteRecipes: List<String>,
+    var favoriteRecipes: List<String>,
     val token: String
 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainScaffold.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainScaffold.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.abhiek.ezrecipes.ui.navbar.*
@@ -15,6 +17,8 @@ import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.profile.ProfileViewModel
+import com.abhiek.ezrecipes.ui.profile.ProfileViewModelFactory
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.currentWindowSize
 import kotlinx.coroutines.CoroutineScope
@@ -28,10 +32,16 @@ fun MainScaffold(
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
+    val context = LocalContext.current
+
+    val profileViewModel = viewModel<ProfileViewModel>(
+        factory = ProfileViewModelFactory(context)
+    )
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            TopBar(scope, navController, widthSizeClass, drawerState)
+            TopBar(scope, navController, widthSizeClass, drawerState, profileViewModel)
         },
         // Show the navigation bar on small screens
         bottomBar = {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainViewModelFactory.kt
@@ -16,7 +16,7 @@ class MainViewModelFactory(private val context: Context): ViewModelProvider.Fact
         if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
             return MainViewModel(
                 recipeRepository = RecipeRepository(
-                    recipeService = RecipeService.instance,
+                    recipeService = RecipeService.getInstance(context),
                     recentRecipeDao = AppDatabase.getInstance(context).recentRecipeDao()
                 ),
                 dataStoreService = DataStoreService(context),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -22,6 +22,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.chef.ChefRepository
+import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.RecentRecipe
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
@@ -33,6 +35,7 @@ import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.profile.ProfileViewModel
 import com.abhiek.ezrecipes.ui.search.RecipeCard
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.ui.util.ErrorAlert
@@ -44,6 +47,7 @@ import kotlinx.coroutines.delay
 @Composable
 fun Home(
     mainViewModel: MainViewModel,
+    profileViewModel: ProfileViewModel,
     onNavigateToRecipe: () -> Unit
 ) {
     val context = LocalContext.current
@@ -171,7 +175,8 @@ fun Home(
                     mainViewModel.recentRecipes.forEach { recentRecipe ->
                         RecipeCard(
                             recipe = recentRecipe.recipe,
-                            width = 350.dp
+                            width = 350.dp,
+                            profileViewModel = profileViewModel
                         ) {
                             mainViewModel.recipe = recentRecipe.recipe
                             onNavigateToRecipe()
@@ -229,9 +234,16 @@ private fun HomePreview(
         RecentRecipe(recipe.id, System.currentTimeMillis(), recipe)
     }
 
+    val chefService = MockChefService
+    val profileViewModel = ProfileViewModel(
+        chefRepository = ChefRepository(chefService),
+        recipeRepository = RecipeRepository(recipeService),
+        dataStoreService = DataStoreService(context)
+    )
+
     EZRecipesTheme {
         Surface {
-            Home(viewModel) {}
+            Home(viewModel, profileViewModel) {}
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -81,7 +81,7 @@ fun NavigationGraph(
                 { slideRightEnter() }
             } else null
         ) {
-            Home(mainViewModel) {
+            Home(mainViewModel, profileViewModel) {
                 navController.navigate(
                     Routes.RECIPE.replace(
                         "{id}", mainViewModel.recipe?.id.toString()
@@ -132,6 +132,7 @@ fun NavigationGraph(
                     SearchResults(
                         mainViewModel,
                         searchViewModel,
+                        profileViewModel,
                         modifier = Modifier.weight(
                             if (widthSizeClass == WindowWidthSizeClass.Medium) 1f else 2f
                         )
@@ -154,7 +155,7 @@ fun NavigationGraph(
             popEnterTransition = { slideRightEnter() },
             popExitTransition = { slideRightExit() }
         ) {
-            SearchResults(mainViewModel, searchViewModel) {
+            SearchResults(mainViewModel, searchViewModel, profileViewModel) {
                 navController.navigate(
                     Routes.RECIPE.replace(
                         "{id}", mainViewModel.recipe?.id.toString()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -51,7 +51,7 @@ fun NavigationGraph(
         factory = MainViewModelFactory(context)
     )
     val searchViewModel = viewModel<SearchViewModel>(
-        factory = SearchViewModelFactory()
+        factory = SearchViewModelFactory(context)
     )
     val glossaryViewModel = viewModel<GlossaryViewModel>(
         factory = GlossaryViewModelFactory(context)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -42,7 +42,6 @@ fun TopBar(
     drawerState: DrawerState? = null,
     profileViewModel: ProfileViewModel
 ) {
-    var isFavorite by remember { mutableStateOf(false) }
     val context = LocalContext.current
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -50,15 +49,11 @@ fun TopBar(
     val isRecipeRoute = currentRoute == Routes.RECIPE
     val recipeId = navBackStackEntry?.arguments?.getString("id")
 
+    val isFavorite = profileViewModel.chef?.favoriteRecipes?.contains(recipeId) ?: false
+
     // Check if the recipe is one of the chef's favorites
     LaunchedEffect(Unit) {
         profileViewModel.getChef()
-    }
-    LaunchedEffect(profileViewModel.chef?.favoriteRecipes) {
-        if (profileViewModel.chef != null) {
-            val favoriteRecipes = profileViewModel.chef?.favoriteRecipes
-            isFavorite = favoriteRecipes?.contains(recipeId) ?: false
-        }
     }
 
     fun shareRecipe(id: String) {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/TopBar.kt
@@ -89,9 +89,12 @@ fun TopBar(
         // Add a favorite and share button on the right side if we're on the recipe screen
         actions = {
             if (isRecipeRoute && recipeId?.toIntOrNull() != null) {
-                IconButton(onClick = {
-                    profileViewModel.toggleFavoriteRecipe(recipeId.toInt(), !isFavorite)
-                }) {
+                IconButton(
+                    onClick = {
+                        profileViewModel.toggleFavoriteRecipe(recipeId.toInt(), !isFavorite)
+                    },
+                    enabled = profileViewModel.chef != null
+                ) {
                     Icon(
                         imageVector = if (isFavorite) {
                             Icons.Filled.Favorite

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -76,7 +76,8 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                     for (recipe in profileViewModel.favoriteRecipes) {
                         RecipeCard(
                             recipe = recipe,
-                            width = 350.dp
+                            width = 350.dp,
+                            profileViewModel = profileViewModel
                         ) {}
                     }
                 }
@@ -100,7 +101,8 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                     for (recipe in profileViewModel.recentRecipes) {
                         RecipeCard(
                             recipe = recipe,
-                            width = 350.dp
+                            width = 350.dp,
+                            profileViewModel = profileViewModel
                         ) {}
                     }
                 }
@@ -124,7 +126,8 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                     for (recipe in profileViewModel.ratedRecipes) {
                         RecipeCard(
                             recipe = recipe,
-                            width = 350.dp
+                            width = 350.dp,
+                            profileViewModel = profileViewModel
                         ) {}
                     }
                 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -430,4 +430,38 @@ class ProfileViewModel(
             }
         }
     }
+
+    fun toggleFavoriteRecipe(recipeId: Int, isFavorite: Boolean) {
+        viewModelScope.launch {
+            isLoading = true
+            val recipeUpdate = RecipeUpdate(isFavorite = isFavorite)
+            val token = getToken()
+            val result = recipeRepository.updateRecipe(recipeId, recipeUpdate, token)
+            isLoading = false
+
+            when (result) {
+                is RecipeResult.Success -> {
+                    Log.d(TAG, "Recipe favorite status updated successfully")
+
+                    if (chef != null) {
+                        if (isFavorite) {
+                            chef!!.favoriteRecipes += recipeId.toString()
+                        } else {
+                            chef!!.favoriteRecipes -= recipeId.toString()
+                        }
+                    }
+
+                    result.response.token?.let { newToken ->
+                        saveToken(newToken)
+                    }
+                }
+                is RecipeResult.Error -> {
+                    Log.w(
+                        TAG, "Failed to update the recipe favorite status :: error: ${
+                        result.recipeError.error
+                    }")
+                }
+            }
+        }
+    }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -442,14 +442,13 @@ class ProfileViewModel(
             when (result) {
                 is RecipeResult.Success -> {
                     Log.d(TAG, "Recipe favorite status updated successfully")
-
-                    if (chef != null) {
-                        if (isFavorite) {
-                            chef!!.favoriteRecipes += recipeId.toString()
+                    chef = chef?.copy(
+                        favoriteRecipes = if (isFavorite) {
+                            chef!!.favoriteRecipes + recipeId.toString()
                         } else {
-                            chef!!.favoriteRecipes -= recipeId.toString()
+                            chef!!.favoriteRecipes - recipeId.toString()
                         }
-                    }
+                    )
 
                     result.response.token?.let { newToken ->
                         saveToken(newToken)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -441,7 +441,6 @@ class ProfileViewModel(
 
             when (result) {
                 is RecipeResult.Success -> {
-                    Log.d(TAG, "Recipe favorite status updated successfully")
                     chef = chef?.copy(
                         favoriteRecipes = if (isFavorite) {
                             chef!!.favoriteRecipes + recipeId.toString()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.ChefService
+import com.abhiek.ezrecipes.data.interceptors.CacheInterceptor
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.recipe.RecipeService
 import com.abhiek.ezrecipes.data.storage.DataStoreService
+import java.util.concurrent.TimeUnit
 
 class ProfileViewModelFactory(private val context: Context): ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
@@ -15,7 +17,14 @@ class ProfileViewModelFactory(private val context: Context): ViewModelProvider.F
         if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
             return ProfileViewModel(
                 chefRepository = ChefRepository(
-                    chefService = ChefService.instance
+                    chefService = ChefService.getInstance(
+                        cacheInterceptor = CacheInterceptor(
+                            context = context,
+                            sizeInMB = 1,
+                            age = 5,
+                            units = TimeUnit.MINUTES
+                        )
+                    )
                 ),
                 recipeRepository = RecipeRepository(
                     recipeService = RecipeService.instance

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelFactory.kt
@@ -5,11 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.ChefService
-import com.abhiek.ezrecipes.data.interceptors.CacheInterceptor
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.recipe.RecipeService
 import com.abhiek.ezrecipes.data.storage.DataStoreService
-import java.util.concurrent.TimeUnit
 
 class ProfileViewModelFactory(private val context: Context): ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
@@ -17,17 +15,10 @@ class ProfileViewModelFactory(private val context: Context): ViewModelProvider.F
         if (modelClass.isAssignableFrom(ProfileViewModel::class.java)) {
             return ProfileViewModel(
                 chefRepository = ChefRepository(
-                    chefService = ChefService.getInstance(
-                        cacheInterceptor = CacheInterceptor(
-                            context = context,
-                            sizeInMB = 1,
-                            age = 5,
-                            units = TimeUnit.MINUTES
-                        )
-                    )
+                    chefService = ChefService.getInstance(context)
                 ),
                 recipeRepository = RecipeRepository(
-                    recipeService = RecipeService.instance
+                    recipeService = RecipeService.getInstance(context)
                 ),
                 dataStoreService = DataStoreService(context)
             ) as T

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
@@ -39,19 +39,13 @@ fun RecipeCard(
     profileViewModel: ProfileViewModel,
     onClick: () -> Unit
 ) {
-    var isFavorite by remember { mutableStateOf(false) }
     val context = LocalContext.current
 
+    val isFavorite = profileViewModel.chef?.favoriteRecipes?.contains(recipe.id.toString()) ?: false
     val calories = recipe.nutrients.firstOrNull { nutrient -> nutrient.name == "Calories" }
 
     LaunchedEffect(Unit) {
         profileViewModel.getChef()
-    }
-    LaunchedEffect(profileViewModel.chef?.favoriteRecipes) {
-        if (profileViewModel.chef != null) {
-            val favoriteRecipes = profileViewModel.chef?.favoriteRecipes
-            isFavorite = favoriteRecipes?.contains(recipe.id.toString()) ?: false
-        }
     }
 
     ElevatedCard(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
@@ -78,9 +78,15 @@ fun RecipeCard(
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.weight(1f)
                 )
-                IconButton(onClick = {
-                    profileViewModel.toggleFavoriteRecipe(recipe.id, !isFavorite)
-                }) {
+                IconButton(
+                    onClick = {
+                        profileViewModel.toggleFavoriteRecipe(recipe.id, !isFavorite)
+                    },
+                    enabled = profileViewModel.chef != null,
+                    colors = IconButtonDefaults.iconButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
                     Icon(
                         imageVector = if (isFavorite) {
                             Icons.Filled.Favorite
@@ -91,8 +97,7 @@ fun RecipeCard(
                             stringResource(R.string.un_favorite_alt)
                         } else {
                             stringResource(R.string.favorite_alt)
-                        },
-                        tint = MaterialTheme.colorScheme.primary
+                        }
                     )
                 }
             }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.data.chef.ChefRepository
+import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
@@ -30,6 +32,7 @@ import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.profile.ProfileViewModel
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
 import com.google.android.play.core.review.testing.FakeReviewManager
@@ -38,6 +41,7 @@ import com.google.android.play.core.review.testing.FakeReviewManager
 fun SearchResults(
     mainViewModel: MainViewModel,
     searchViewModel: SearchViewModel,
+    profileViewModel: ProfileViewModel,
     modifier: Modifier = Modifier,
     onNavigateToRecipe: () -> Unit
 ) {
@@ -79,7 +83,7 @@ fun SearchResults(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(searchViewModel.recipes) { recipe ->
-                    RecipeCard(recipe) {
+                    RecipeCard(recipe = recipe, profileViewModel = profileViewModel) {
                         mainViewModel.recipe = recipe
                         onNavigateToRecipe()
                     }
@@ -134,9 +138,16 @@ private fun SearchResultsPreview(
     val searchViewModel = SearchViewModel(RecipeRepository((recipeService)))
     searchViewModel.recipes = recipes
 
+    val chefService = MockChefService
+    val profileViewModel = ProfileViewModel(
+        chefRepository = ChefRepository(chefService),
+        recipeRepository = RecipeRepository(recipeService),
+        dataStoreService = DataStoreService(context)
+    )
+
     EZRecipesTheme {
         Surface {
-            SearchResults(recipeViewModel, searchViewModel) {}
+            SearchResults(recipeViewModel, searchViewModel, profileViewModel) {}
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchViewModelFactory.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchViewModelFactory.kt
@@ -1,17 +1,18 @@
 package com.abhiek.ezrecipes.ui.search
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.recipe.RecipeService
 
-class SearchViewModelFactory: ViewModelProvider.Factory {
+class SearchViewModelFactory(private val context: Context): ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(SearchViewModel::class.java)) {
             return SearchViewModel(
                 recipeRepository = RecipeRepository(
-                    recipeService = RecipeService.instance
+                    recipeService = RecipeService.getInstance(context)
                 )
             ) as T
         }

--- a/EZRecipes/build.gradle.kts
+++ b/EZRecipes/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     // Kotlin versions: https://kotlinlang.org/docs/releases.html#release-details
     val kotlinVersion = "2.1.0"
 
-    id("com.android.application") version "8.7.3" apply false
+    id("com.android.application") version "8.8.0" apply false
     id("org.jetbrains.kotlin.android") version kotlinVersion apply false
     // Version must match Kotlin: https://github.com/google/ksp/releases
     id("com.google.devtools.ksp") version "$kotlinVersion-1.0.29" apply false

--- a/EZRecipes/gradle/wrapper/gradle-wrapper.properties
+++ b/EZRecipes/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 23 13:42:55 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
<div>
  <img src="https://github.com/user-attachments/assets/db573160-c09d-4392-85d9-c62dee0daec5" alt="home" width="300">
  <img src="https://github.com/user-attachments/assets/e06a12a5-141c-49b0-965a-1476737e8e2f" alt="recipe" width="300">
</div>

_The Android implementation of https://github.com/Abhiek187/ez-recipes-web/issues/314_

We're finally doing something about the favorite button! Since this calls an API, we account for a delay until the recipe is favorited/unfavorited. The UI will reflect this change in real time. The favorite button can be used in the recipe screen on the top bar or a recipe card (either on the home or search screen). I had trouble getting this to work initially, but I eventually got it to work by creating a new copy of the chef object and using a plain variable instead of creating another state variable.

One thing I noticed while testing this is that I'm making a lot of API calls to check/modify the chef's state. I'm quickly reaching the rate limit of 60 calls/hr defined in the server. I could interpret this in a couple of ways:
1. The rate limit is too strict and I should increase it. This was mainly meant to avoid hitting spoonacular's API quota, but since most of the APIs we're calling hit MongoDB and Firebase, this isn't as much of a concern.
2. We're making too many API calls at once in the app and should optimize for performance.

I could perform 1 on the server side if testing becomes too difficult, but I decided to do something about 2 and added a caching layer to the chef and recipe APIs. The GET calls should cache every 5 minutes. We can't do much about the PATCH calls. There may be other optimizations, such as not passing the ViewModel everywhere, but if it works, I'll leave it for now and worry about optimizations closer to release.