### PR TITLE
Feature/rating

### DIFF
--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -121,7 +121,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
-    testImplementation("io.mockk:mockk:1.13.14")
+    testImplementation("io.mockk:mockk:1.13.16")
 
     androidTestImplementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
     androidTestImplementation("androidx.test.ext:junit:1.2.1")

--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -73,9 +73,9 @@ android {
 }
 
 dependencies {
-    val composeBomVersion = "2024.12.01"
+    val composeBomVersion = "2025.01.00"
     val lifecycleVersion = "2.8.7"
-    val activityVersion = "1.9.3"
+    val activityVersion = "1.10.0"
     val materialVersion = "1.7.6"
     val material3Version = "1.3.1"
     val retrofitVersion = "2.11.0"
@@ -97,7 +97,7 @@ dependencies {
     implementation("androidx.compose.material3:material3:$material3Version")
     implementation("androidx.compose.material3:material3-window-size-class:$material3Version")
     implementation("androidx.navigation:navigation-compose:2.8.5")
-    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("androidx.datastore:datastore-preferences:1.1.2")
 
     // AsyncImage
     implementation("io.coil-kt:coil-compose:2.7.0")

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/EZRecipesInstrumentedTest.kt
@@ -163,10 +163,7 @@ internal class EZRecipesInstrumentedTest {
             .onNodeWithContentDescription(activity.getString(R.string.recipe_link))
             .assertHasClickAction()
 
-        // Check that the two recipe buttons are clickable
-        val madeButton = composeTestRule
-            .onNodeWithContentDescription(activity.getString(R.string.made_button))
-        madeButton.assertHasClickAction()
+        // Check that the recipe button is clickable
         val showRecipeButton = composeTestRule
             .onNodeWithContentDescription(activity.getString(R.string.show_recipe_button))
         showRecipeButton.assertHasClickAction()

--- a/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/ProfileTest.kt
+++ b/EZRecipes/app/src/androidTest/java/com/abhiek/ezrecipes/ProfileTest.kt
@@ -69,16 +69,16 @@ internal class ProfileTest(
         passwordField.performTextInput("password")
         // The eye icon appears twice on the sign up form
         composeTestRule
-            .onAllNodesWithContentDescription("Hide password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_hide))
             .assertCountEquals(0)
         composeTestRule
-            .onAllNodesWithContentDescription("Show password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_show))
             .assertCountEquals(1)
             .onFirst()
             .performClick()
             .assertDoesNotExist()
         composeTestRule
-            .onAllNodesWithContentDescription("Hide password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_hide))
             .assertCountEquals(1)
             .onFirst()
             .performClick()
@@ -131,16 +131,16 @@ internal class ProfileTest(
             .assertCountEquals(2)
         passwordField.performTextInput("word")
         composeTestRule
-            .onAllNodesWithContentDescription("Hide password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_hide))
             .assertCountEquals(0)
         composeTestRule
-            .onAllNodesWithContentDescription("Show password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_show))
             .assertCountEquals(2)
             .onFirst()
             .performClick()
             .assertDoesNotExist()
         composeTestRule
-            .onAllNodesWithContentDescription("Hide password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_hide))
             .assertCountEquals(2)
             .onFirst()
             .performClick()
@@ -169,16 +169,16 @@ internal class ProfileTest(
         passwordMatchError.assertExists()
         confirmPasswordField.performTextInput("password")
         composeTestRule
-            .onAllNodesWithContentDescription("Hide password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_hide))
             .assertCountEquals(0)
         composeTestRule
-            .onAllNodesWithContentDescription("Show password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_show))
             .assertCountEquals(2)
             .onLast()
             .performClick()
             .assertDoesNotExist()
         composeTestRule
-            .onAllNodesWithContentDescription("Hide password")
+            .onAllNodesWithContentDescription(activity.getString(R.string.password_hide))
             .assertCountEquals(2)
             .onLast()
             .performClick()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Chef.kt
@@ -3,7 +3,7 @@ package com.abhiek.ezrecipes.data.models
 data class Chef(
     val uid: String,
     val email: String,
-    var emailVerified: Boolean,
+    val emailVerified: Boolean,
     val ratings: Map<String, Int>,
     val recentRecipes: Map<String, String>,
     val favoriteRecipes: List<String>,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Recipe.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/models/Recipe.kt
@@ -25,7 +25,7 @@ data class Recipe(
     val ingredients: List<Ingredient>,
     val instructions: List<Instruction>,
     var token: String? = null, // searchSequenceToken for pagination
-    var totalRatings: Int? = null,
-    var averageRating: Double? = null,
-    var views: Int? = null
+    val totalRatings: Int? = null,
+    val averageRating: Double? = null,
+    val views: Int? = null
 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
@@ -127,8 +127,11 @@ fun LoginForm(
                     Icon(
                         imageVector = if (showPassword) Icons.Filled.Visibility
                             else Icons.Filled.VisibilityOff,
-                        contentDescription = if (showPassword) "Hide password"
-                            else "Show password"
+                        contentDescription = if (showPassword) {
+                            stringResource(R.string.password_hide)
+                        } else {
+                            stringResource(R.string.password_show)
+                        }
                     )
                 }
             },

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
@@ -134,8 +134,11 @@ fun SignUpForm(
                     Icon(
                         imageVector = if (showPassword) Icons.Filled.Visibility
                             else Icons.Filled.VisibilityOff,
-                        contentDescription = if (showPassword) "Hide password"
-                            else "Show password"
+                        contentDescription = if (showPassword) {
+                            stringResource(R.string.password_hide)
+                        } else {
+                            stringResource(R.string.password_show)
+                        }
                     )
                 }
             },
@@ -174,8 +177,11 @@ fun SignUpForm(
                     Icon(
                         imageVector = if (showPassword) Icons.Filled.Visibility
                             else Icons.Filled.VisibilityOff,
-                        contentDescription = if (showPassword) "Hide password"
-                            else "Show password"
+                        contentDescription = if (showPassword) {
+                            stringResource(R.string.password_hide)
+                        } else {
+                            stringResource(R.string.password_show)
+                        }
                     )
                 }
             },

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -105,7 +105,12 @@ fun NavigationGraph(
             popEnterTransition = { slideRightEnter() },
             popExitTransition = { slideRightExit() }
         ) { backStackEntry ->
-            Recipe(mainViewModel, isWideScreen, backStackEntry.arguments?.getString("id"))
+            Recipe(
+                mainViewModel,
+                profileViewModel,
+                isWideScreen,
+                backStackEntry.arguments?.getString("id")
+            )
         }
         composable(
             Routes.SEARCH,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -454,8 +454,34 @@ class ProfileViewModel(
                     }
                 }
                 is RecipeResult.Error -> {
-                    Log.w(
-                        TAG, "Failed to update the recipe favorite status :: error: ${
+                    Log.w(TAG, "Failed to update the recipe favorite status :: error: ${
+                        result.recipeError.error
+                    }")
+                }
+            }
+        }
+    }
+
+    fun rateRecipe(recipeId: Int, rating: Int) {
+        viewModelScope.launch {
+            isLoading = true
+            val recipeUpdate = RecipeUpdate(rating = rating)
+            val token = getToken()
+            val result = recipeRepository.updateRecipe(recipeId, recipeUpdate, token)
+            isLoading = false
+
+            when (result) {
+                is RecipeResult.Success -> {
+                    chef = chef?.copy(
+                        ratings = chef!!.ratings + (recipeId.toString() to rating)
+                    )
+
+                    result.response.token?.let { newToken ->
+                        saveToken(newToken)
+                    }
+                }
+                is RecipeResult.Error -> {
+                    Log.w(TAG, "Failed to rate the recipe :: error: ${
                         result.recipeError.error
                     }")
                 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/UpdatePasswordForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/UpdatePasswordForm.kt
@@ -74,8 +74,11 @@ fun UpdatePasswordForm(profileViewModel: ProfileViewModel, onDismiss: () -> Unit
                     Icon(
                         imageVector = if (showPassword) Icons.Filled.Visibility
                             else Icons.Filled.VisibilityOff,
-                        contentDescription = if (showPassword) "Hide password"
-                            else "Show password"
+                        contentDescription = if (showPassword) {
+                            stringResource(R.string.password_hide)
+                        } else {
+                            stringResource(R.string.password_show)
+                        }
                     )
                 }
             },
@@ -114,8 +117,11 @@ fun UpdatePasswordForm(profileViewModel: ProfileViewModel, onDismiss: () -> Unit
                     Icon(
                         imageVector = if (showPassword) Icons.Filled.Visibility
                             else Icons.Filled.VisibilityOff,
-                        contentDescription = if (showPassword) "Hide password"
-                            else "Show password"
+                        contentDescription = if (showPassword) {
+                            stringResource(R.string.password_hide)
+                        } else {
+                            stringResource(R.string.password_show)
+                        }
                     )
                 }
             },

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ReceiptLong
-import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -122,6 +121,11 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                 text = recipe.views?.toShorthand() ?: "0"
             )
         }
+        RecipeRating(
+            averageRating = recipe.averageRating,
+            totalRatings = recipe.totalRatings ?: 0,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
 
         if (recipe.types.isNotEmpty() && !(recipe.types contentEquals listOf(MealType.UNKNOWN))) {
             Text(
@@ -164,38 +168,11 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     modifier = Modifier.size(50.dp), // avoid the oval shape
                     shape = CircleShape,
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error
-                    ),
-                    onClick = { println("Nice! Hope it was tasty!") },
-                    // Reduce padding to make the icon take up more space
-                    contentPadding = PaddingValues(8.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Restaurant,
-                        contentDescription = stringResource(R.string.made_button),
-                        tint = MaterialTheme.colorScheme.onError
-                    )
-                }
-                Text(
-                    text = stringResource(R.string.made_button),
-                    fontSize = 16.sp,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.labelLarge
-                )
-            }
-
-            Column(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Button(
-                    modifier = Modifier.size(50.dp),
-                    shape = CircleShape,
-                    colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.tertiary,
                         contentColor = MaterialTheme.colorScheme.onTertiary
                     ),
                     onClick = { onClickFindRecipe() },
+                    // Reduce padding to make the icon take up more space
                     contentPadding = PaddingValues(8.dp),
                     enabled = !isLoading
                 ) {
@@ -211,10 +188,9 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
                     style = MaterialTheme.typography.labelLarge
                 )
             }
-        }
-
-        if (isLoading) {
-            CircularProgressIndicator()
+            if (isLoading) {
+                CircularProgressIndicator()
+            }
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -35,7 +35,13 @@ import com.abhiek.ezrecipes.utils.contentEquals
 import com.abhiek.ezrecipes.utils.toShorthand
 
 @Composable
-fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Unit) {
+fun RecipeHeader(
+    recipe: Recipe,
+    isLoading: Boolean,
+    myRating: Int? = null,
+    onRate: (Int) -> Unit = {},
+    onClickFindRecipe: () -> Unit = {}
+) {
     val context = LocalContext.current
 
     // Make the image caption clickable
@@ -124,6 +130,8 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
         RecipeRating(
             averageRating = recipe.averageRating,
             totalRatings = recipe.totalRatings ?: 0,
+            myRating = myRating,
+            onRate = onRate,
             modifier = Modifier.padding(bottom = 8.dp)
         )
 
@@ -213,7 +221,7 @@ private fun RecipeHeaderPreview(
             RecipeHeader(
                 recipe = MockRecipeService.recipes[2],
                 isLoading = isLoading,
-                onClickFindRecipe = {}
+                myRating = 4
             )
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeHeader.kt
@@ -115,7 +115,7 @@ fun RecipeHeader(recipe: Recipe, isLoading: Boolean, onClickFindRecipe: () -> Un
             )
             Icon(
                 imageVector = Icons.Filled.Visibility,
-                contentDescription = "views"
+                contentDescription = stringResource(R.string.views_alt)
             )
             Text(
                 text = recipe.views?.toShorthand() ?: "0"

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -49,19 +50,19 @@ fun RecipeRating(averageRating: Double?, totalRatings: Int?, modifier: Modifier 
                 if (i < stars || (i == stars && averageRating >= stars)) {
                     Icon(
                         imageVector = Icons.Filled.Star,
-                        contentDescription = "Filled star",
+                        contentDescription = stringResource(R.string.star_filled),
                         tint = starColor
                     )
                 } else if (i == stars && averageRating < stars) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.StarHalf,
-                        contentDescription = "Half star",
+                        contentDescription = stringResource(R.string.star_half),
                         tint = starColor
                     )
                 } else {
                     Icon(
                         imageVector = Icons.Outlined.StarRate,
-                        contentDescription = "Empty star",
+                        contentDescription = stringResource(R.string.star_empty),
                         tint = starColor
                     )
                 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
@@ -34,7 +34,7 @@ import kotlin.math.roundToInt
 @Composable
 fun RecipeRating(
     averageRating: Double?,
-    totalRatings: Int?,
+    totalRatings: Int,
     myRating: Int? = null,
     onRate: (Int) -> Unit = {},
     modifier: Modifier = Modifier
@@ -42,8 +42,9 @@ fun RecipeRating(
     val context = LocalContext.current
 
     // If the user has rated the recipe, show their rating instead of the average
-    val starRating = myRating?.toDouble() ?: averageRating
-    val stars = starRating?.roundToInt() ?: 0
+    // If there are no ratings, show all empty stars
+    val starRating = myRating?.toDouble() ?: averageRating ?: 0.0
+    val stars = starRating.roundToInt()
     val starColor = if (isSystemInDarkTheme()) {
         if (myRating != null) Orange700 else MaterialTheme.colorScheme.tertiary
     } else {
@@ -51,10 +52,9 @@ fun RecipeRating(
     }
 
     Row(
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.clearAndSetSemantics {
-            contentDescription = if (starRating == null) {
+            contentDescription = if (starRating == 0.0) {
                 context.getString(R.string.star_rating_none)
             } else {
                 context.getString(
@@ -65,41 +65,39 @@ fun RecipeRating(
             role = Role.Image
         }
     ) {
-        if (starRating != null) {
-            for (i in 1..5) {
-                IconButton(
-                    onClick = { onRate(i) }
-                ) {
-                    if (i < stars || (i == stars && starRating >= stars)) {
-                        Icon(
-                            imageVector = Icons.Filled.Star,
-                            contentDescription = context.resources.getQuantityString(
-                                R.plurals.star_rating_input, i, i
-                            ),
-                            tint = starColor
-                        )
-                    } else if (i == stars && starRating < stars) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.StarHalf,
-                            contentDescription = context.resources.getQuantityString(
-                                R.plurals.star_rating_input, i, i
-                            ),
-                            tint = starColor
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.Outlined.StarRate,
-                            contentDescription = context.resources.getQuantityString(
-                                R.plurals.star_rating_input, i, i
-                            ),
-                            tint = starColor
-                        )
-                    }
+        for (i in 1..5) {
+            IconButton(
+                onClick = { onRate(i) }
+            ) {
+                if (i < stars || (i == stars && starRating >= stars)) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = context.resources.getQuantityString(
+                            R.plurals.star_rating_input, i, i
+                        ),
+                        tint = starColor
+                    )
+                } else if (i == stars && starRating < stars) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.StarHalf,
+                        contentDescription = context.resources.getQuantityString(
+                            R.plurals.star_rating_input, i, i
+                        ),
+                        tint = starColor
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Outlined.StarRate,
+                        contentDescription = context.resources.getQuantityString(
+                            R.plurals.star_rating_input, i, i
+                        ),
+                        tint = starColor
+                    )
                 }
             }
         }
         Text(
-            text = if (averageRating != null && totalRatings != null) {
+            text = if (averageRating != null) {
                 "(${averageRating.round(places = 1)}/5, " + context.resources.getQuantityString(
                     R.plurals.total_ratings, totalRatings, totalRatings.toShorthand()
                 ) + ")"
@@ -112,13 +110,13 @@ fun RecipeRating(
 
 private data class RecipeRatingState(
     val averageRating: Double?,
-    val totalRatings: Int?,
+    val totalRatings: Int,
     val myRating: Int?
 )
 
 private class RecipeRatingPreviewParameterProvider: PreviewParameterProvider<RecipeRatingState> {
     override val values = sequenceOf(
-        RecipeRatingState(averageRating = null, totalRatings = null, myRating = null),
+        RecipeRatingState(averageRating = null, totalRatings = 0, myRating = null),
         RecipeRatingState(averageRating = 5.0, totalRatings = 1, myRating = null),
         RecipeRatingState(averageRating = 4.1, totalRatings = 1934, myRating = null),
         RecipeRatingState(averageRating = 2.5, totalRatings = 10, myRating = null),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
@@ -36,6 +36,7 @@ fun RecipeRating(
     averageRating: Double?,
     totalRatings: Int,
     myRating: Int? = null,
+    enabled: Boolean = true,
     onRate: (Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
@@ -67,60 +68,61 @@ fun RecipeRating(
     ) {
         for (i in 1..5) {
             IconButton(
-                onClick = { onRate(i) }
+                onClick = { onRate(i) },
+                enabled = enabled,
+                colors = IconButtonDefaults.iconButtonColors(
+                    contentColor = starColor
+                )
             ) {
                 if (i < stars || (i == stars && starRating >= stars)) {
                     Icon(
                         imageVector = Icons.Filled.Star,
                         contentDescription = context.resources.getQuantityString(
                             R.plurals.star_rating_input, i, i
-                        ),
-                        tint = starColor
+                        )
                     )
                 } else if (i == stars && starRating < stars) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.StarHalf,
                         contentDescription = context.resources.getQuantityString(
                             R.plurals.star_rating_input, i, i
-                        ),
-                        tint = starColor
+                        )
                     )
                 } else {
                     Icon(
                         imageVector = Icons.Outlined.StarRate,
                         contentDescription = context.resources.getQuantityString(
                             R.plurals.star_rating_input, i, i
-                        ),
-                        tint = starColor
+                        )
                     )
                 }
             }
         }
         Text(
-            text = if (averageRating != null) {
-                "(${averageRating.round(places = 1)}/5, " + context.resources.getQuantityString(
-                    R.plurals.total_ratings, totalRatings, totalRatings.toShorthand()
-                ) + ")"
-            } else {
-                "(0 ratings)"
-            }
+            text = "(" + (if (averageRating != null) {
+                "${averageRating.round(places = 1)}/5, "
+            } else "") + context.resources.getQuantityString(
+                R.plurals.total_ratings, totalRatings, totalRatings.toShorthand()
+            ) + ")"
         )
     }
 }
 
 private data class RecipeRatingState(
-    val averageRating: Double?,
-    val totalRatings: Int,
-    val myRating: Int?
+    val averageRating: Double? = null,
+    val totalRatings: Int = 0,
+    val myRating: Int? = null,
+    val enabled: Boolean = true
 )
 
 private class RecipeRatingPreviewParameterProvider: PreviewParameterProvider<RecipeRatingState> {
     override val values = sequenceOf(
-        RecipeRatingState(averageRating = null, totalRatings = 0, myRating = null),
-        RecipeRatingState(averageRating = 5.0, totalRatings = 1, myRating = null),
-        RecipeRatingState(averageRating = 4.1, totalRatings = 1934, myRating = null),
-        RecipeRatingState(averageRating = 2.5, totalRatings = 10, myRating = null),
-        RecipeRatingState(averageRating = 3.625, totalRatings = 582, myRating = null),
+        RecipeRatingState(),
+        RecipeRatingState(enabled = false),
+        RecipeRatingState(averageRating = 5.0, totalRatings = 1),
+        RecipeRatingState(averageRating = 4.1, totalRatings = 1934),
+        RecipeRatingState(averageRating = 2.5, totalRatings = 10),
+        RecipeRatingState(averageRating = 3.625, totalRatings = 582),
         RecipeRatingState(averageRating = 1.0, totalRatings = 8, myRating = 3)
     )
 }
@@ -141,7 +143,8 @@ private fun RecipeRatingPreview(
                 RecipeRating(
                     averageRating = state.averageRating,
                     totalRatings = state.totalRatings,
-                    myRating = state.myRating
+                    myRating = state.myRating,
+                    enabled = state.enabled
                 )
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
@@ -29,7 +29,7 @@ import com.abhiek.ezrecipes.utils.toShorthand
 import kotlin.math.roundToInt
 
 @Composable
-fun RecipeRating(averageRating: Double?, totalRatings: Int) {
+fun RecipeRating(averageRating: Double?, totalRatings: Int?, modifier: Modifier = Modifier) {
     val context = LocalContext.current
 
     val stars = averageRating?.roundToInt() ?: 0
@@ -41,7 +41,8 @@ fun RecipeRating(averageRating: Double?, totalRatings: Int) {
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
     ) {
         if (averageRating != null) {
             for (i in 1..5) {
@@ -67,14 +68,12 @@ fun RecipeRating(averageRating: Double?, totalRatings: Int) {
             }
         }
         Text(
-            text = if (averageRating != null) {
+            text = if (averageRating != null && totalRatings != null) {
                 "(${averageRating.round(places = 1)}/5, " + context.resources.getQuantityString(
                     R.plurals.ratings, totalRatings, totalRatings.toShorthand()
                 ) + ")"
             } else {
-                "(" + context.resources.getQuantityString(
-                    R.plurals.ratings, totalRatings, totalRatings.toShorthand()
-                ) + ")"
+                "(0 ratings)"
             }
         )
     }
@@ -82,12 +81,12 @@ fun RecipeRating(averageRating: Double?, totalRatings: Int) {
 
 private data class RecipeRatingState(
     val averageRating: Double?,
-    val totalRatings: Int
+    val totalRatings: Int?
 )
 
 private class RecipeRatingPreviewParameterProvider: PreviewParameterProvider<RecipeRatingState> {
     override val values = sequenceOf(
-        RecipeRatingState(averageRating = null, totalRatings = 0),
+        RecipeRatingState(averageRating = null, totalRatings = null),
         RecipeRatingState(averageRating = 5.0, totalRatings = 1),
         RecipeRatingState(averageRating = 4.1, totalRatings = 1934),
         RecipeRatingState(averageRating = 2.5, totalRatings = 10),

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
@@ -6,15 +6,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.StarHalf
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarRate
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -25,53 +25,83 @@ import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.Amber700
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.ui.theme.Orange700
+import com.abhiek.ezrecipes.ui.theme.Orange900
 import com.abhiek.ezrecipes.utils.round
 import com.abhiek.ezrecipes.utils.toShorthand
 import kotlin.math.roundToInt
 
 @Composable
-fun RecipeRating(averageRating: Double?, totalRatings: Int?, modifier: Modifier = Modifier) {
+fun RecipeRating(
+    averageRating: Double?,
+    totalRatings: Int?,
+    myRating: Int? = null,
+    onRate: (Int) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
     val context = LocalContext.current
 
-    val stars = averageRating?.roundToInt() ?: 0
+    // If the user has rated the recipe, show their rating instead of the average
+    val starRating = myRating?.toDouble() ?: averageRating
+    val stars = starRating?.roundToInt() ?: 0
     val starColor = if (isSystemInDarkTheme()) {
-        MaterialTheme.colorScheme.tertiary
+        if (myRating != null) Orange700 else MaterialTheme.colorScheme.tertiary
     } else {
-        Amber700
+        if (myRating != null) Orange900 else Amber700
     }
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
+        modifier = modifier.clearAndSetSemantics {
+            contentDescription = if (starRating == null) {
+                context.getString(R.string.star_rating_none)
+            } else {
+                context.getString(
+                    if (myRating != null) R.string.star_rating_user else R.string.star_rating_average,
+                    starRating
+                )
+            }
+            role = Role.Image
+        }
     ) {
-        if (averageRating != null) {
+        if (starRating != null) {
             for (i in 1..5) {
-                if (i < stars || (i == stars && averageRating >= stars)) {
-                    Icon(
-                        imageVector = Icons.Filled.Star,
-                        contentDescription = stringResource(R.string.star_filled),
-                        tint = starColor
-                    )
-                } else if (i == stars && averageRating < stars) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.StarHalf,
-                        contentDescription = stringResource(R.string.star_half),
-                        tint = starColor
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Outlined.StarRate,
-                        contentDescription = stringResource(R.string.star_empty),
-                        tint = starColor
-                    )
+                IconButton(
+                    onClick = { onRate(i) }
+                ) {
+                    if (i < stars || (i == stars && starRating >= stars)) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = context.resources.getQuantityString(
+                                R.plurals.star_rating_input, i, i
+                            ),
+                            tint = starColor
+                        )
+                    } else if (i == stars && starRating < stars) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.StarHalf,
+                            contentDescription = context.resources.getQuantityString(
+                                R.plurals.star_rating_input, i, i
+                            ),
+                            tint = starColor
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Outlined.StarRate,
+                            contentDescription = context.resources.getQuantityString(
+                                R.plurals.star_rating_input, i, i
+                            ),
+                            tint = starColor
+                        )
+                    }
                 }
             }
         }
         Text(
             text = if (averageRating != null && totalRatings != null) {
                 "(${averageRating.round(places = 1)}/5, " + context.resources.getQuantityString(
-                    R.plurals.ratings, totalRatings, totalRatings.toShorthand()
+                    R.plurals.total_ratings, totalRatings, totalRatings.toShorthand()
                 ) + ")"
             } else {
                 "(0 ratings)"
@@ -82,16 +112,18 @@ fun RecipeRating(averageRating: Double?, totalRatings: Int?, modifier: Modifier 
 
 private data class RecipeRatingState(
     val averageRating: Double?,
-    val totalRatings: Int?
+    val totalRatings: Int?,
+    val myRating: Int?
 )
 
 private class RecipeRatingPreviewParameterProvider: PreviewParameterProvider<RecipeRatingState> {
     override val values = sequenceOf(
-        RecipeRatingState(averageRating = null, totalRatings = null),
-        RecipeRatingState(averageRating = 5.0, totalRatings = 1),
-        RecipeRatingState(averageRating = 4.1, totalRatings = 1934),
-        RecipeRatingState(averageRating = 2.5, totalRatings = 10),
-        RecipeRatingState(averageRating = 3.625, totalRatings = 582)
+        RecipeRatingState(averageRating = null, totalRatings = null, myRating = null),
+        RecipeRatingState(averageRating = 5.0, totalRatings = 1, myRating = null),
+        RecipeRatingState(averageRating = 4.1, totalRatings = 1934, myRating = null),
+        RecipeRatingState(averageRating = 2.5, totalRatings = 10, myRating = null),
+        RecipeRatingState(averageRating = 3.625, totalRatings = 582, myRating = null),
+        RecipeRatingState(averageRating = 1.0, totalRatings = 8, myRating = 3)
     )
 }
 
@@ -110,7 +142,8 @@ private fun RecipeRatingPreview(
                 Spacer(modifier = Modifier.height(50.dp))
                 RecipeRating(
                     averageRating = state.averageRating,
-                    totalRatings = state.totalRatings
+                    totalRatings = state.totalRatings,
+                    myRating = state.myRating
                 )
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/recipe/RecipeRating.kt
@@ -1,0 +1,118 @@
+package com.abhiek.ezrecipes.ui.recipe
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.StarHalf
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.StarRate
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.abhiek.ezrecipes.R
+import com.abhiek.ezrecipes.ui.previews.DevicePreviews
+import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
+import com.abhiek.ezrecipes.ui.previews.FontPreviews
+import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
+import com.abhiek.ezrecipes.ui.theme.Amber700
+import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
+import com.abhiek.ezrecipes.utils.round
+import com.abhiek.ezrecipes.utils.toShorthand
+import kotlin.math.roundToInt
+
+@Composable
+fun RecipeRating(averageRating: Double?, totalRatings: Int) {
+    val context = LocalContext.current
+
+    val stars = averageRating?.roundToInt() ?: 0
+    val starColor = if (isSystemInDarkTheme()) {
+        MaterialTheme.colorScheme.tertiary
+    } else {
+        Amber700
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (averageRating != null) {
+            for (i in 1..5) {
+                if (i < stars || (i == stars && averageRating >= stars)) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = "Filled star",
+                        tint = starColor
+                    )
+                } else if (i == stars && averageRating < stars) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.StarHalf,
+                        contentDescription = "Half star",
+                        tint = starColor
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Outlined.StarRate,
+                        contentDescription = "Empty star",
+                        tint = starColor
+                    )
+                }
+            }
+        }
+        Text(
+            text = if (averageRating != null) {
+                "(${averageRating.round(places = 1)}/5, " + context.resources.getQuantityString(
+                    R.plurals.ratings, totalRatings, totalRatings.toShorthand()
+                ) + ")"
+            } else {
+                "(" + context.resources.getQuantityString(
+                    R.plurals.ratings, totalRatings, totalRatings.toShorthand()
+                ) + ")"
+            }
+        )
+    }
+}
+
+private data class RecipeRatingState(
+    val averageRating: Double?,
+    val totalRatings: Int
+)
+
+private class RecipeRatingPreviewParameterProvider: PreviewParameterProvider<RecipeRatingState> {
+    override val values = sequenceOf(
+        RecipeRatingState(averageRating = null, totalRatings = 0),
+        RecipeRatingState(averageRating = 5.0, totalRatings = 1),
+        RecipeRatingState(averageRating = 4.1, totalRatings = 1934),
+        RecipeRatingState(averageRating = 2.5, totalRatings = 10),
+        RecipeRatingState(averageRating = 3.625, totalRatings = 582)
+    )
+}
+
+@DevicePreviews
+@DisplayPreviews
+@FontPreviews
+@OrientationPreviews
+@Composable
+private fun RecipeRatingPreview(
+    @PreviewParameter(RecipeRatingPreviewParameterProvider::class) state: RecipeRatingState
+) {
+    EZRecipesTheme {
+        Surface {
+            // The status bar and camera get in the way
+            Column {
+                Spacer(modifier = Modifier.height(50.dp))
+                RecipeRating(
+                    averageRating = state.averageRating,
+                    totalRatings = state.totalRatings
+                )
+            }
+        }
+    }
+}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
@@ -27,6 +27,7 @@ import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.profile.ProfileViewModel
+import com.abhiek.ezrecipes.ui.recipe.RecipeRating
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
 import com.abhiek.ezrecipes.utils.boldAnnotatedString
@@ -101,6 +102,16 @@ fun RecipeCard(
                     )
                 }
             }
+
+            RecipeRating(
+                averageRating = recipe.averageRating,
+                totalRatings = recipe.totalRatings ?: 0,
+                myRating = profileViewModel.chef?.ratings?.get(recipe.id.toString()),
+                enabled = profileViewModel.chef != null,
+                onRate = { rating ->
+                    profileViewModel.rateRecipe(rating, recipe.id)
+                }
+            )
 
             Row(
                 horizontalArrangement = Arrangement.SpaceAround,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Color.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/theme/Color.kt
@@ -11,3 +11,7 @@ val Blue700 = Color(0xFF1976D2)
 val Amber300 = Color(0xFFFFD54F)
 val Amber500 = Color(0xFFFFC107)
 val Amber700 = Color(0xFFFFA000)
+
+// Other colors
+val Orange700 = Color(0xFFF57C00)
+val Orange900 = Color(0xFFE65100)

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/util/Accordion.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/util/Accordion.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -50,7 +52,11 @@ fun Accordion(
                 imageVector = Icons.Default.run {
                     if (isExpanded) KeyboardArrowUp else KeyboardArrowDown
                 },
-                contentDescription = if (isExpanded) "Expanded" else "Collapsed",
+                contentDescription = if (isExpanded) {
+                    stringResource(R.string.accordion_collapse)
+                } else {
+                    stringResource(R.string.accordion_expand)
+                },
                 tint = MaterialTheme.colorScheme.onSurface.copy(
                     alpha = 0.6f
                 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/NumberExtensions.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/utils/NumberExtensions.kt
@@ -50,3 +50,23 @@ fun Int.toShorthand(): String {
         }
     }
 }
+
+/**
+ * Rounds a number to the specified number of decimal places. Trailing zeros are removed.
+ *
+ * @param places the number of decimal places to round to
+ * @return the rounded number as a String
+ * @throws IllegalArgumentException if `places` is negative
+ */
+fun Double.round(places: Int): String {
+    if (places < 0) {
+        throw IllegalArgumentException("The number of decimal places must be non-negative")
+    }
+
+    val roundedString = "%.${places}f".format(this)
+    return if (roundedString.contains('.')) {
+        roundedString.trimEnd('0').trimEnd('.')
+    } else {
+        roundedString
+    }
+}

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -50,13 +50,17 @@
         <item quantity="other">Time: %1$d minutes</item>
     </plurals>
     <string name="views_alt">views</string>
-    <plurals name="ratings">
+    <string name="star_rating_none">No ratings available</string>
+    <string name="star_rating_average">Average rating: %1$d out of 5 stars</string>
+    <string name="star_rating_user">Your rating: %1$d out of 5 stars</string>
+    <plurals name="star_rating_input">
+        <item quantity="one">Rate %1$d star</item>
+        <item quantity="other">Rate %1$d stars</item>
+    </plurals>
+    <plurals name="total_ratings">
         <item quantity="one">%1$s rating</item>
         <item quantity="other">%1$s ratings</item>
     </plurals>
-    <string name="star_filled">filled star</string>
-    <string name="star_half">half star</string>
-    <string name="star_empty">empty star</string>
 
     <string name="recipe_meal_types">Great for: %1$s</string>
     <string name="recipe_cuisines">Cuisines: %1$s</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
         <item quantity="one">%1$s rating</item>
         <item quantity="other">%1$s ratings</item>
     </plurals>
+    <string name="rating_error">You must be signed in to rate this recipe</string>
 
     <string name="recipe_meal_types">Great for: %1$s</string>
     <string name="recipe_cuisines">Cuisines: %1$s</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -49,6 +49,10 @@
         <item quantity="one">Time: %1$d minute</item>
         <item quantity="other">Time: %1$d minutes</item>
     </plurals>
+    <plurals name="ratings">
+        <item quantity="one">%1$s rating</item>
+        <item quantity="other">%1$s ratings</item>
+    </plurals>
 
     <string name="recipe_meal_types">Great for: %1$s</string>
     <string name="recipe_cuisines">Cuisines: %1$s</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -56,7 +56,6 @@
 
     <string name="recipe_meal_types">Great for: %1$s</string>
     <string name="recipe_cuisines">Cuisines: %1$s</string>
-    <string name="made_button">I Made This!</string>
     <string name="show_recipe_button">Show Me Another Recipe!</string>
 
     <string name="nutrition_facts">Nutrition Facts</string>

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -49,10 +49,14 @@
         <item quantity="one">Time: %1$d minute</item>
         <item quantity="other">Time: %1$d minutes</item>
     </plurals>
+    <string name="views_alt">views</string>
     <plurals name="ratings">
         <item quantity="one">%1$s rating</item>
         <item quantity="other">%1$s ratings</item>
     </plurals>
+    <string name="star_filled">filled star</string>
+    <string name="star_half">half star</string>
+    <string name="star_empty">empty star</string>
 
     <string name="recipe_meal_types">Great for: %1$s</string>
     <string name="recipe_cuisines">Cuisines: %1$s</string>
@@ -119,6 +123,8 @@
     <string name="profile_favorites">💖 Favorites</string>
     <string name="profile_recently_viewed">⌚ Recently Viewed</string>
     <string name="profile_ratings">⭐ Ratings</string>
+    <string name="accordion_expand">Expand</string>
+    <string name="accordion_collapse">Collapse</string>
     <!-- Newlines add additional spacing before each line (but is ok for a bulleted list) -->
     <string name="login_message">
         Signing up for an account is free and gives you great perks, including:\n
@@ -138,6 +144,8 @@
     <string name="sign_in_sub_header">Don\'t have an account?</string>
     <string name="username_field">Username</string>
     <string name="password_field">Password</string>
+    <string name="password_show">Show password</string>
+    <string name="password_hide">Hide password</string>
     <string name="password_forget">Forgot password?</string>
     <string name="sign_in_success">Signed in successfully!</string>
     <string name="sign_out_success">Signed out successfully!</string>

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/utils/NumberExtensionsTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/utils/NumberExtensionsTest.kt
@@ -1,6 +1,7 @@
 package com.abhiek.ezrecipes.utils
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -24,5 +25,26 @@ internal class NumberExtensionsTest {
         // Build.VERSION.SDK_INT will always be 0 in unit tests
         val actualStr = inputNum.toShorthand()
         assertEquals(expectedStr, actualStr)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "0,0,0",
+        "0.5,0,1",
+        "1.8175,2,1.82",
+        "3.14159265359,5,3.14159",
+        "4.2047,2,4.2",
+        "666,1,666",
+        "666,-1,?"
+    )
+    fun round(inputNum: Double, places: Int, expectedNum: String) {
+        if (places < 0) {
+            assertThrows(IllegalArgumentException::class.java) {
+                inputNum.round(places)
+            }
+        } else {
+            val actualNum = inputNum.round(places)
+            assertEquals(expectedNum, actualNum)
+        }
     }
 }


### PR DESCRIPTION
<div>
  <img src="https://github.com/user-attachments/assets/709e06c0-50e1-4633-b491-6d35225635e9" alt="rating on cards" width="300">
  <img src="https://github.com/user-attachments/assets/787e641e-bf99-4435-8207-0a711c60391f" alt="sample rating" width="300">
  <img src="https://github.com/user-attachments/assets/8cff57d6-ba88-42f5-bc51-96c975aa4d88" alt="rating with toast" width="300">
</div>

_The Android implementation of https://github.com/Abhiek187/ez-recipes-web/issues/315_

I'm finally replacing the "I Made This!" button with a rating system. Chefs can now see ratings on their recipes. If they're logged in, they can rate themselves. Otherwise, they will be told to sign in. (The ratings will be disabled on the recipe cards.) The rating will be darkened to indicate that the user submitted their rating, but the average and total ratings won't update immediately. This should be fine. The recipe stats will be updated the next time the recipe is fetched. I still need to figure out how to update the cache for offline use, but that will be for a future story.

...Oh and I took care of localizing all the strings I've been hardcoding in these newer composables. That includes all the alt text for a nice, accessible experience.

We're getting close to finishing all the updates and that's exciting! The additional filters may require a server update, but the rest of the backlog is purely UI changes. I've implemented all the new APIs created in the server and it's cool to see these updates occur in the app itself! I've been slowly chipping away at this milestone, but hopefully, it will pay off in the end. (Not literally, of course, this is for fun and not for profit. 😊)