### PR TITLE
Populate Profile

### DIFF
--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     val activityVersion = "1.10.0"
     val materialVersion = "1.7.6"
     val material3Version = "1.3.1"
+    val coroutineVersion = "1.10.1"
     val retrofitVersion = "2.11.0"
     val roomVersion = "2.6.1"
     val googlePlayVersion = "2.0.2"
@@ -98,6 +99,7 @@ dependencies {
     implementation("androidx.compose.material3:material3-window-size-class:$material3Version")
     implementation("androidx.navigation:navigation-compose:2.8.5")
     implementation("androidx.datastore:datastore-preferences:1.1.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion")
 
     // AsyncImage
     implementation("io.coil-kt:coil-compose:2.7.0")
@@ -120,7 +122,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion")
     testImplementation("io.mockk:mockk:1.13.16")
 
     androidTestImplementation(platform("androidx.compose:compose-bom:$composeBomVersion"))

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/glossary/Glossary.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/glossary/Glossary.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -23,6 +24,9 @@ import com.abhiek.ezrecipes.utils.boldAnnotatedString
 
 @Composable
 fun Glossary(terms: List<Term>) {
+    // Sort all the terms alphabetically for ease of reference
+    val sortedTerms = remember(terms) { terms.sortedBy { term -> term.word } }
+
     if (terms.isEmpty()) {
         // Show that the terms are loading
         Box(
@@ -35,9 +39,8 @@ fun Glossary(terms: List<Term>) {
         LazyColumn(
             modifier = Modifier.padding(8.dp)
         ) {
-            // Sort all the terms alphabetically for ease of reference
             itemsIndexed(
-                items = terms.sortedBy { it.word },
+                items = sortedTerms,
                 key = { _, term -> term._id }
             ) { index, term ->
                 Text(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.delay
 fun Home(
     mainViewModel: MainViewModel,
     profileViewModel: ProfileViewModel,
-    onNavigateToRecipe: () -> Unit
+    onNavigateToRecipe: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val activity = context.getActivity()
@@ -243,7 +243,7 @@ private fun HomePreview(
 
     EZRecipesTheme {
         Surface {
-            Home(viewModel, profileViewModel) {}
+            Home(viewModel, profileViewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/home/Home.kt
@@ -90,7 +90,7 @@ fun Home(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_STOP &&
-                context.getActivity()?.isChangingConfigurations != true) {
+                activity?.isChangingConfigurations != true) {
                 // Stop any network calls while switching tabs,
                 // except when rotating or folding the screen
                 mainViewModel.job?.cancel()

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/ForgotPasswordForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/ForgotPasswordForm.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -51,7 +53,9 @@ fun ForgotPasswordForm(
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.padding(8.dp)
+        modifier = Modifier
+            .padding(8.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         if (!profileViewModel.emailSent) {
             Text(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/ForgotPasswordForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/ForgotPasswordForm.kt
@@ -54,7 +54,7 @@ fun ForgotPasswordForm(
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier
-            .padding(8.dp)
+            .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
         if (!profileViewModel.emailSent) {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginDialog.kt
@@ -1,15 +1,14 @@
 package com.abhiek.ezrecipes.ui.login
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -29,15 +28,12 @@ import com.abhiek.ezrecipes.utils.Routes
 @Composable
 fun LoginDialog(profileViewModel: ProfileViewModel, onDismiss: () -> Unit) {
     Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(
-            usePlatformDefaultWidth = false, // occupy full screen width
-            decorFitsSystemWindows = false // allow custom layout around system bars
-        )
+        onDismissRequest = onDismiss
     ) {
         // Add a background so the dialog appears on top of the main content
         Surface(
             modifier = Modifier
+                .widthIn(max = 400.dp)
                 .fillMaxSize()
                 .wrapContentHeight(Alignment.CenterVertically),
             color = MaterialTheme.colorScheme.background

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -64,7 +66,9 @@ fun LoginForm(
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.padding(8.dp)
+        modifier = Modifier
+            .padding(8.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         Text(
             text = stringResource(R.string.sign_in_header),
@@ -75,7 +79,8 @@ fun LoginForm(
         ) {
             Text(
                 text = stringResource(R.string.sign_in_sub_header),
-                style = MaterialTheme.typography.titleLarge
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f, false)
             )
             TextButton(
                 onClick = {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/LoginForm.kt
@@ -67,7 +67,7 @@ fun LoginForm(
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier
-            .padding(8.dp)
+            .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
         Text(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
@@ -72,7 +72,7 @@ fun SignUpForm(
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier
-            .padding(8.dp)
+            .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
         Text(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/SignUpForm.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -69,7 +71,9 @@ fun SignUpForm(
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.padding(8.dp)
+        modifier = Modifier
+            .padding(8.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         Text(
             text = stringResource(R.string.sign_up_header),
@@ -80,7 +84,8 @@ fun SignUpForm(
         ) {
             Text(
                 text = stringResource(R.string.sign_up_sub_header),
-                style = MaterialTheme.typography.titleLarge
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f, false)
             )
             TextButton(
                 onClick = {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
@@ -1,6 +1,8 @@
 package com.abhiek.ezrecipes.ui.login
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.*
@@ -47,7 +49,9 @@ fun VerifyEmail(
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier.padding(8.dp)
+        modifier = Modifier
+            .padding(8.dp)
+            .verticalScroll(rememberScrollState())
     ) {
         Text(
             text = stringResource(R.string.email_verify_header),
@@ -72,7 +76,8 @@ fun VerifyEmail(
             ) {
                 Text(
                     text = stringResource(R.string.email_verify_retry_text),
-                    style = MaterialTheme.typography.bodyMedium
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f, false)
                 )
                 TextButton(
                     onClick = {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/login/VerifyEmail.kt
@@ -50,7 +50,7 @@ fun VerifyEmail(
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier
-            .padding(8.dp)
+            .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
         Text(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/navbar/NavigationGraph.kt
@@ -135,16 +135,16 @@ fun NavigationGraph(
                         modifier = Modifier.weight(1f)
                     ) {}
                     SearchResults(
-                        mainViewModel,
                         searchViewModel,
                         profileViewModel,
                         modifier = Modifier.weight(
                             if (widthSizeClass == WindowWidthSizeClass.Medium) 1f else 2f
                         )
-                    ) {
+                    ) { recipe ->
+                        mainViewModel.recipe = recipe
                         navController.navigate(
                             Routes.RECIPE.replace(
-                                "{id}", mainViewModel.recipe?.id.toString()
+                                "{id}", recipe.id.toString()
                             )
                         ) {
                             launchSingleTop = true
@@ -160,10 +160,11 @@ fun NavigationGraph(
             popEnterTransition = { slideRightEnter() },
             popExitTransition = { slideRightExit() }
         ) {
-            SearchResults(mainViewModel, searchViewModel, profileViewModel) {
+            SearchResults(searchViewModel, profileViewModel) { recipe ->
+                mainViewModel.recipe = recipe
                 navController.navigate(
                     Routes.RECIPE.replace(
-                        "{id}", mainViewModel.recipe?.id.toString()
+                        "{id}", recipe.id.toString()
                     )
                 ) {
                     launchSingleTop = true
@@ -182,11 +183,26 @@ fun NavigationGraph(
                     uriPattern = "${Constants.RECIPE_WEB_ORIGIN}/${Routes.PROFILE}"
                 }
             ),
+            exitTransition = if (mainViewModel.recipe != null) {
+                { slideLeftExit() }
+            } else null,
+            popEnterTransition = if (mainViewModel.recipe != null) {
+                { slideRightEnter() }
+            } else null
         ) { backStackEntry ->
             Profile(
                 profileViewModel,
                 deepLinkAction = backStackEntry.arguments?.getString("action")
-            )
+            ) { recipe ->
+                mainViewModel.recipe = recipe
+                navController.navigate(
+                    Routes.RECIPE.replace(
+                        "{id}", recipe.id.toString()
+                    )
+                ) {
+                    launchSingleTop = true
+                }
+            }
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -24,6 +24,7 @@ import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.AuthState
+import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.storage.DataStoreService
@@ -36,7 +37,11 @@ import com.abhiek.ezrecipes.utils.Constants
 import com.abhiek.ezrecipes.utils.getActivity
 
 @Composable
-fun Profile(profileViewModel: ProfileViewModel, deepLinkAction: String? = null) {
+fun Profile(
+    profileViewModel: ProfileViewModel,
+    deepLinkAction: String? = null,
+    onNavigateToRecipe: (Recipe) -> Unit = {}
+) {
     val authState = profileViewModel.authState
     val chef = profileViewModel.chef
 
@@ -90,7 +95,7 @@ fun Profile(profileViewModel: ProfileViewModel, deepLinkAction: String? = null) 
     }
 
     if (authState == AuthState.AUTHENTICATED && chef != null) {
-        ProfileLoggedIn(chef, profileViewModel)
+        ProfileLoggedIn(chef, profileViewModel, onNavigateToRecipe)
     } else if (authState == AuthState.UNAUTHENTICATED) {
         ProfileLoggedOut(profileViewModel)
     } else {

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/Profile.kt
@@ -2,13 +2,13 @@ package com.abhiek.ezrecipes.ui.profile
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,6 +17,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
@@ -30,6 +33,7 @@ import com.abhiek.ezrecipes.ui.previews.FontPreviews
 import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
+import com.abhiek.ezrecipes.utils.getActivity
 
 @Composable
 fun Profile(profileViewModel: ProfileViewModel, deepLinkAction: String? = null) {
@@ -37,6 +41,7 @@ fun Profile(profileViewModel: ProfileViewModel, deepLinkAction: String? = null) 
     val chef = profileViewModel.chef
 
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     LaunchedEffect(Unit, deepLinkAction) {
         // Check if the user is authenticated every time the profile tab is launched or deep linked
@@ -64,6 +69,23 @@ fun Profile(profileViewModel: ProfileViewModel, deepLinkAction: String? = null) 
                     Toast.LENGTH_SHORT
                 ).show()
             }
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP &&
+                context.getActivity()?.isChangingConfigurations != true) {
+                // Stop any network calls while switching tabs,
+                // except when rotating or folding the screen
+                profileViewModel.job?.cancel()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -114,7 +114,6 @@ fun ProfileLoggedIn(
         ) {
             loadRecipeCards(favoriteRecipes)
         }
-
         Accordion(
             header = stringResource(R.string.profile_recently_viewed),
             expandByDefault = false,
@@ -127,7 +126,6 @@ fun ProfileLoggedIn(
         ) {
             loadRecipeCards(recentRecipes)
         }
-
         Accordion(
             header = stringResource(R.string.profile_ratings),
             expandByDefault = false,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -52,6 +52,42 @@ fun ProfileLoggedIn(
         dialogToShow = null
     }
 
+    @Composable
+    fun loadRecipeCards(recipes: List<Recipe?>) {
+        if (recipes.isEmpty()) {
+            Text(
+                text = stringResource(R.string.no_results),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp)
+            )
+        } else {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+            ) {
+                for (recipe in recipes) {
+                    if (recipe == null) {
+                        RecipeCardLoader()
+                    } else {
+                        RecipeCard(
+                            recipe = recipe,
+                            width = 350.dp,
+                            profileViewModel = profileViewModel,
+                            chefCopy = chef
+                        ) {
+                            onNavigateToRecipe(recipe)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier
@@ -76,28 +112,7 @@ fun ProfileLoggedIn(
                 }
             }
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier
-                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                    .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
-            ) {
-                for (recipe in favoriteRecipes) {
-                    if (recipe == null) {
-                        RecipeCardLoader()
-                    } else {
-                        RecipeCard(
-                            recipe = recipe,
-                            width = 350.dp,
-                            profileViewModel = profileViewModel,
-                            chefCopy = chef
-                        ) {
-                            onNavigateToRecipe(recipe)
-                        }
-                    }
-                }
-            }
+            loadRecipeCards(favoriteRecipes)
         }
 
         Accordion(
@@ -110,20 +125,7 @@ fun ProfileLoggedIn(
                 }
             }
         ) {
-            for (recipe in recentRecipes) {
-                if (recipe == null) {
-                    RecipeCardLoader()
-                } else {
-                    RecipeCard(
-                        recipe = recipe,
-                        width = 350.dp,
-                        profileViewModel = profileViewModel,
-                        chefCopy = chef
-                    ) {
-                        onNavigateToRecipe(recipe)
-                    }
-                }
-            }
+            loadRecipeCards(recentRecipes)
         }
 
         Accordion(
@@ -136,20 +138,7 @@ fun ProfileLoggedIn(
                 }
             }
         ) {
-            for (recipe in ratedRecipes) {
-                if (recipe == null) {
-                    RecipeCardLoader()
-                } else {
-                    RecipeCard(
-                        recipe = recipe,
-                        width = 350.dp,
-                        profileViewModel = profileViewModel,
-                        chefCopy = chef
-                    ) {
-                        onNavigateToRecipe(recipe)
-                    }
-                }
-            }
+            loadRecipeCards(ratedRecipes)
         }
 
         Button(

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -35,14 +35,12 @@ import com.abhiek.ezrecipes.utils.Routes
 @Composable
 fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
     var dialogToShow by remember { mutableStateOf<String?>(null) }
+    val favoriteRecipes by profileViewModel.favoriteRecipes.collectAsState()
+    val recentRecipes by profileViewModel.recentRecipes.collectAsState()
+    val ratedRecipes by profileViewModel.ratedRecipes.collectAsState()
 
     val onDismiss = {
         dialogToShow = null
-    }
-
-    LaunchedEffect(Unit) {
-        // Start loading all the recipe cards
-        profileViewModel.getAllChefRecipes()
     }
 
     Column(
@@ -60,22 +58,24 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
 
         Accordion(
             header = stringResource(R.string.profile_favorites),
-            expandByDefault = false
+            expandByDefault = false,
+            onExpand = {
+                profileViewModel.getAllFavoriteRecipes()
+            }
         ) {
-            // TODO: change to a loading condition
-            if (true) {
-                RecipeCardLoader()
-            } else {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState())
-                ) {
-                    for (recipe in profileViewModel.favoriteRecipes) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+            ) {
+                for (recipeState in favoriteRecipes) {
+                    if (recipeState.isLoading) {
+                        RecipeCardLoader()
+                    } else if (recipeState.recipe != null) {
                         RecipeCard(
-                            recipe = recipe,
+                            recipe = recipeState.recipe,
                             width = 350.dp,
                             profileViewModel = profileViewModel
                         ) {}
@@ -86,50 +86,40 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
 
         Accordion(
             header = stringResource(R.string.profile_recently_viewed),
-            expandByDefault = false
+            expandByDefault = false,
+            onExpand = {
+                profileViewModel.getAllRecentRecipes()
+            }
         ) {
-            if (true) {
-                RecipeCardLoader()
-            } else {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState())
-                ) {
-                    for (recipe in profileViewModel.recentRecipes) {
-                        RecipeCard(
-                            recipe = recipe,
-                            width = 350.dp,
-                            profileViewModel = profileViewModel
-                        ) {}
-                    }
+            for (recipeState in recentRecipes) {
+                if (recipeState.isLoading) {
+                    RecipeCardLoader()
+                } else if (recipeState.recipe != null) {
+                    RecipeCard(
+                        recipe = recipeState.recipe,
+                        width = 350.dp,
+                        profileViewModel = profileViewModel
+                    ) {}
                 }
             }
         }
 
         Accordion(
             header = stringResource(R.string.profile_ratings),
-            expandByDefault = false
+            expandByDefault = false,
+            onExpand = {
+                profileViewModel.getAllRatedRecipes()
+            }
         ) {
-            if (true) {
-                RecipeCardLoader()
-            } else {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState())
-                ) {
-                    for (recipe in profileViewModel.ratedRecipes) {
-                        RecipeCard(
-                            recipe = recipe,
-                            width = 350.dp,
-                            profileViewModel = profileViewModel
-                        ) {}
-                    }
+            for (recipeState in ratedRecipes) {
+                if (recipeState.isLoading) {
+                    RecipeCardLoader()
+                } else if (recipeState.recipe != null) {
+                    RecipeCard(
+                        recipe = recipeState.recipe,
+                        width = 350.dp,
+                        profileViewModel = profileViewModel
+                    ) {}
                 }
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -70,12 +70,12 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState())
             ) {
-                for (recipeState in favoriteRecipes) {
-                    if (recipeState.isLoading) {
+                for (recipe in favoriteRecipes) {
+                    if (recipe == null) {
                         RecipeCardLoader()
-                    } else if (recipeState.recipe != null) {
+                    } else {
                         RecipeCard(
-                            recipe = recipeState.recipe,
+                            recipe = recipe,
                             width = 350.dp,
                             profileViewModel = profileViewModel
                         ) {}
@@ -91,12 +91,12 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                 profileViewModel.getAllRecentRecipes()
             }
         ) {
-            for (recipeState in recentRecipes) {
-                if (recipeState.isLoading) {
+            for (recipe in recentRecipes) {
+                if (recipe == null) {
                     RecipeCardLoader()
-                } else if (recipeState.recipe != null) {
+                } else {
                     RecipeCard(
-                        recipe = recipeState.recipe,
+                        recipe = recipe,
                         width = 350.dp,
                         profileViewModel = profileViewModel
                     ) {}
@@ -111,12 +111,12 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                 profileViewModel.getAllRatedRecipes()
             }
         ) {
-            for (recipeState in ratedRecipes) {
-                if (recipeState.isLoading) {
+            for (recipe in ratedRecipes) {
+                if (recipe == null) {
                     RecipeCardLoader()
-                } else if (recipeState.recipe != null) {
+                } else {
                     RecipeCard(
-                        recipe = recipeState.recipe,
+                        recipe = recipe,
                         width = 350.dp,
                         profileViewModel = profileViewModel
                     ) {}

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileLoggedIn.kt
@@ -19,6 +19,7 @@ import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.Chef
+import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
 import com.abhiek.ezrecipes.data.storage.DataStoreService
@@ -33,8 +34,16 @@ import com.abhiek.ezrecipes.ui.util.ErrorAlert
 import com.abhiek.ezrecipes.utils.Routes
 
 @Composable
-fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
+fun ProfileLoggedIn(
+    chef: Chef,
+    profileViewModel: ProfileViewModel,
+    onNavigateToRecipe: (Recipe) -> Unit = {}
+) {
     var dialogToShow by remember { mutableStateOf<String?>(null) }
+    var didExpandFavorites by remember { mutableStateOf(false) }
+    var didExpandRecent by remember { mutableStateOf(false) }
+    var didExpandRates by remember { mutableStateOf(false) }
+
     val favoriteRecipes by profileViewModel.favoriteRecipes.collectAsState()
     val recentRecipes by profileViewModel.recentRecipes.collectAsState()
     val ratedRecipes by profileViewModel.ratedRecipes.collectAsState()
@@ -60,7 +69,11 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
             header = stringResource(R.string.profile_favorites),
             expandByDefault = false,
             onExpand = {
-                profileViewModel.getAllFavoriteRecipes()
+                // Only fetch the recipes once per load
+                if (!didExpandFavorites) {
+                    profileViewModel.getAllFavoriteRecipes()
+                    didExpandFavorites = true
+                }
             }
         ) {
             Row(
@@ -77,8 +90,11 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                         RecipeCard(
                             recipe = recipe,
                             width = 350.dp,
-                            profileViewModel = profileViewModel
-                        ) {}
+                            profileViewModel = profileViewModel,
+                            chefCopy = chef
+                        ) {
+                            onNavigateToRecipe(recipe)
+                        }
                     }
                 }
             }
@@ -88,7 +104,10 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
             header = stringResource(R.string.profile_recently_viewed),
             expandByDefault = false,
             onExpand = {
-                profileViewModel.getAllRecentRecipes()
+                if (!didExpandRecent) {
+                    profileViewModel.getAllRecentRecipes()
+                    didExpandRecent = true
+                }
             }
         ) {
             for (recipe in recentRecipes) {
@@ -98,8 +117,11 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                     RecipeCard(
                         recipe = recipe,
                         width = 350.dp,
-                        profileViewModel = profileViewModel
-                    ) {}
+                        profileViewModel = profileViewModel,
+                        chefCopy = chef
+                    ) {
+                        onNavigateToRecipe(recipe)
+                    }
                 }
             }
         }
@@ -108,7 +130,10 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
             header = stringResource(R.string.profile_ratings),
             expandByDefault = false,
             onExpand = {
-                profileViewModel.getAllRatedRecipes()
+                if (!didExpandRates) {
+                    profileViewModel.getAllRatedRecipes()
+                    didExpandRates = true
+                }
             }
         ) {
             for (recipe in ratedRecipes) {
@@ -118,8 +143,11 @@ fun ProfileLoggedIn(chef: Chef, profileViewModel: ProfileViewModel) {
                     RecipeCard(
                         recipe = recipe,
                         width = 350.dp,
-                        profileViewModel = profileViewModel
-                    ) {}
+                        profileViewModel = profileViewModel,
+                        chefCopy = chef
+                    ) {
+                        onNavigateToRecipe(recipe)
+                    }
                 }
             }
         }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -421,7 +421,11 @@ class ProfileViewModel(
         val chef = this.chef ?: return
 
         viewModelScope.launch {
-            val recipeIds = chef.recentRecipes.mapNotNull { (id, timestamp) -> id.toIntOrNull() }
+            // Sort the recipe IDs by most recent timestamp
+            val recipeIds = chef.recentRecipes
+                .mapNotNull { (id, timestamp) -> id.toIntOrNull() to timestamp }
+                .sortedByDescending { it.second }
+                .mapNotNull { it.first }
 
             val initialRecipes = recipeIds.map { null }
             _recentRecipes.update { initialRecipes }
@@ -459,7 +463,7 @@ class ProfileViewModel(
         val chef = this.chef ?: return
 
         viewModelScope.launch {
-            val recipeIds = chef.ratings.mapNotNull { (id, rating) -> id.toIntOrNull() }
+            val recipeIds = chef.ratings.mapNotNull { (id, _) -> id.toIntOrNull() }
 
             val initialRecipes = recipeIds.map { null }
             _ratedRecipes.update { initialRecipes }
@@ -485,7 +489,7 @@ class ProfileViewModel(
                 }
 
                 jobs.awaitAll()
-                _favoriteRecipes.update { currentState ->
+                _ratedRecipes.update { currentState ->
                     currentState.filterNotNull()
                 }
             }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/RecipeCard.kt
@@ -18,6 +18,7 @@ import coil.compose.AsyncImage
 import com.abhiek.ezrecipes.R
 import com.abhiek.ezrecipes.data.chef.ChefRepository
 import com.abhiek.ezrecipes.data.chef.MockChefService
+import com.abhiek.ezrecipes.data.models.Chef
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
@@ -38,15 +39,20 @@ fun RecipeCard(
     recipe: Recipe,
     width: Dp? = null,
     profileViewModel: ProfileViewModel,
+    chefCopy: Chef? = null,
     onClick: () -> Unit
 ) {
     val context = LocalContext.current
 
-    val isFavorite = profileViewModel.chef?.favoriteRecipes?.contains(recipe.id.toString()) ?: false
+    val chef = chefCopy ?: profileViewModel.chef
+    val isFavorite = chef?.favoriteRecipes?.contains(recipe.id.toString()) ?: false
     val calories = recipe.nutrients.firstOrNull { nutrient -> nutrient.name == "Calories" }
 
     LaunchedEffect(Unit) {
-        profileViewModel.getChef()
+        // Avoid fetching the chef if it's already available
+        if (chefCopy == null) {
+            profileViewModel.getChef()
+        }
     }
 
     ElevatedCard(
@@ -83,7 +89,7 @@ fun RecipeCard(
                     onClick = {
                         profileViewModel.toggleFavoriteRecipe(recipe.id, !isFavorite)
                     },
-                    enabled = profileViewModel.chef != null,
+                    enabled = chef != null,
                     colors = IconButtonDefaults.iconButtonColors(
                         contentColor = MaterialTheme.colorScheme.primary
                     )
@@ -106,8 +112,8 @@ fun RecipeCard(
             RecipeRating(
                 averageRating = recipe.averageRating,
                 totalRatings = recipe.totalRatings ?: 0,
-                myRating = profileViewModel.chef?.ratings?.get(recipe.id.toString()),
-                enabled = profileViewModel.chef != null,
+                myRating = chef?.ratings?.get(recipe.id.toString()),
+                enabled = chef != null,
                 onRate = { rating ->
                     profileViewModel.rateRecipe(rating, recipe.id)
                 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -82,7 +82,10 @@ fun SearchResults(
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(searchViewModel.recipes) { recipe ->
+                items(
+                    items = searchViewModel.recipes,
+                    key = { recipe -> recipe.id }
+                ) { recipe ->
                     RecipeCard(
                         recipe = recipe,
                         profileViewModel = profileViewModel,

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/search/SearchResults.kt
@@ -25,9 +25,7 @@ import com.abhiek.ezrecipes.data.chef.MockChefService
 import com.abhiek.ezrecipes.data.models.Recipe
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
-import com.abhiek.ezrecipes.data.storage.AppDatabase
 import com.abhiek.ezrecipes.data.storage.DataStoreService
-import com.abhiek.ezrecipes.ui.MainViewModel
 import com.abhiek.ezrecipes.ui.previews.DevicePreviews
 import com.abhiek.ezrecipes.ui.previews.DisplayPreviews
 import com.abhiek.ezrecipes.ui.previews.FontPreviews
@@ -35,16 +33,18 @@ import com.abhiek.ezrecipes.ui.previews.OrientationPreviews
 import com.abhiek.ezrecipes.ui.profile.ProfileViewModel
 import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 import com.abhiek.ezrecipes.utils.Constants
-import com.google.android.play.core.review.testing.FakeReviewManager
 
 @Composable
 fun SearchResults(
-    mainViewModel: MainViewModel,
     searchViewModel: SearchViewModel,
     profileViewModel: ProfileViewModel,
     modifier: Modifier = Modifier,
-    onNavigateToRecipe: () -> Unit
+    onNavigateToRecipe: (Recipe) -> Unit = {}
 ) {
+    LaunchedEffect(Unit) {
+        profileViewModel.getChef()
+    }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.padding(8.dp)
@@ -83,9 +83,12 @@ fun SearchResults(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(searchViewModel.recipes) { recipe ->
-                    RecipeCard(recipe = recipe, profileViewModel = profileViewModel) {
-                        mainViewModel.recipe = recipe
-                        onNavigateToRecipe()
+                    RecipeCard(
+                        recipe = recipe,
+                        profileViewModel = profileViewModel,
+                        chefCopy = profileViewModel.chef
+                    ) {
+                        onNavigateToRecipe(recipe)
                     }
                 }
                 // Invisible detector when the user scrolls to the bottom of the list
@@ -128,13 +131,6 @@ private fun SearchResultsPreview(
 ) {
     val context = LocalContext.current
     val recipeService = MockRecipeService
-    val recentRecipeDao = AppDatabase.getInstance(context, inMemory = true).recentRecipeDao()
-
-    val recipeViewModel = MainViewModel(
-        recipeRepository = RecipeRepository(recipeService, recentRecipeDao),
-        dataStoreService = DataStoreService(context),
-        reviewManager = FakeReviewManager(context)
-    )
     val searchViewModel = SearchViewModel(RecipeRepository((recipeService)))
     searchViewModel.recipes = recipes
 
@@ -147,7 +143,7 @@ private fun SearchResultsPreview(
 
     EZRecipesTheme {
         Surface {
-            SearchResults(recipeViewModel, searchViewModel, profileViewModel) {}
+            SearchResults(searchViewModel, profileViewModel)
         }
     }
 }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/util/Accordion.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/util/Accordion.kt
@@ -27,6 +27,8 @@ import com.abhiek.ezrecipes.ui.theme.EZRecipesTheme
 fun Accordion(
     header: String,
     expandByDefault: Boolean = true,
+    onExpand: () -> Unit = {},
+    onCollapse: () -> Unit = {},
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -40,6 +42,7 @@ fun Accordion(
                 .padding(8.dp)
                 .clickable {
                     isExpanded = !isExpanded
+                    if (isExpanded) onExpand() else onCollapse()
                 }
         ) {
             Text(

--- a/EZRecipes/app/src/main/res/values/strings.xml
+++ b/EZRecipes/app/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <!-- Recipe Screen -->
     <string name="no_recipe">No recipe loaded</string>
     <string name="recipe_link">Open recipe source</string>
+    <!-- Formatter syntax: -->
+    <!-- https://developer.android.com/reference/java/util/Formatter.html#format-string-syntax -->
     <string name="image_copyright">Image © %1$s</string>
 
     <plurals name="recipe_time">
@@ -51,7 +53,8 @@
     </plurals>
     <string name="views_alt">views</string>
     <string name="star_rating_none">No ratings available</string>
-    <string name="star_rating_average">Average rating: %1$d out of 5 stars</string>
+    <!-- f = double, d = int -->
+    <string name="star_rating_average">Average rating: %1$.1f out of 5 stars</string>
     <string name="star_rating_user">Your rating: %1$d out of 5 stars</string>
     <plurals name="star_rating_input">
         <item quantity="one">Rate %1$d star</item>

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
@@ -538,6 +538,84 @@ internal class ProfileViewModelTest {
     }
 
     @Test
+    fun getAllFavoriteRecipesSuccess() = runTest {
+        // Given a chef with favorite recipes
+        viewModel.getChef()
+
+        // When getting all favorite recipes
+        viewModel.getAllFavoriteRecipes()
+
+        // Then all the recipes are fetched
+        assertEquals(viewModel.favoriteRecipes.value.size,
+            mockChefService.chef.favoriteRecipes.size)
+    }
+
+    @Test
+    fun getAllFavoriteRecipesError() = runTest {
+        // Given a chef with favorite recipes
+        viewModel.getChef()
+
+        // When getting all favorite recipes and an error occurs
+        mockRecipeService.isSuccess = false
+        viewModel.getAllFavoriteRecipes()
+
+        // Then no recipes are fetched
+        assertEquals(viewModel.favoriteRecipes.value.size, 0)
+    }
+
+    @Test
+    fun getAllRecentRecipesSuccess() = runTest {
+        // Given a chef with recent recipes
+        viewModel.getChef()
+
+        // When getting all recent recipes
+        viewModel.getAllRecentRecipes()
+
+        // Then all the recipes are fetched
+        assertEquals(viewModel.recentRecipes.value.size,
+            mockChefService.chef.recentRecipes.size)
+    }
+
+    @Test
+    fun getAllRecentRecipesError() = runTest {
+        // Given a chef with recent recipes
+        viewModel.getChef()
+
+        // When getting all recent recipes and an error occurs
+        mockRecipeService.isSuccess = false
+        viewModel.getAllRecentRecipes()
+
+        // Then no recipes are fetched
+        assertEquals(viewModel.recentRecipes.value.size, 0)
+    }
+
+    @Test
+    fun getAllRatedRecipesSuccess() = runTest {
+        // Given a chef with rated recipes
+        viewModel.getChef()
+
+        // When getting all rated recipes
+        viewModel.getAllRatedRecipes()
+
+        // Then all the recipes are fetched
+        assertEquals(viewModel.ratedRecipes.value.size,
+            mockChefService.chef.ratings.size)
+    }
+
+    @Test
+    fun getAllRatedRecipesError() = runTest {
+        // Given a chef with rated recipes
+        viewModel.getChef()
+
+        // When getting all rated recipes and an error occurs
+        mockRecipeService.isSuccess = false
+        viewModel.getAllRatedRecipes()
+
+        // Then no recipes are fetched
+        assertEquals(viewModel.ratedRecipes.value.size, 0)
+    }
+
+    @Test
     fun favoriteRecipeSuccess() = runTest {
         // Given a recipe and a valid token
         val recipeId = 1

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
@@ -270,11 +270,11 @@ internal class ProfileViewModelTest {
         assertFalse(viewModel.showAlert)
         assertEquals(viewModel.chef, Chef(
             uid = mockChefService.loginResponse.uid,
-            email = username,
+            email = mockChefService.chef.email,
             emailVerified = mockChefService.loginResponse.emailVerified,
-            ratings = mapOf(),
-            recentRecipes = mapOf(),
-            favoriteRecipes = listOf(),
+            ratings = mockChefService.chef.ratings,
+            recentRecipes = mockChefService.chef.recentRecipes,
+            favoriteRecipes = mockChefService.chef.favoriteRecipes,
             token = mockChefService.loginResponse.token
         ))
         assertEquals(viewModel.authState, AuthState.AUTHENTICATED)


### PR DESCRIPTION
<div>
  <img src="https://github.com/user-attachments/assets/8859fcbc-207c-46db-8567-ccc147de40bf" alt="profile-favorites" width="300">
  <img src="https://github.com/user-attachments/assets/a16d8046-3ad0-4266-8944-9d5deef4fd7a" alt="profile-ratings" width="300">
</div>

_The Android implementation of https://github.com/Abhiek187/ez-recipes-web/issues/311_

Despite the issue name, this PR was concerned with populating all the accordions in the chef's profile. Since we need to make multiple API calls to fetch recipes, I utilized StateFlows to appease Google's design philosophy. Together with the accordions and skeleton loaders created a while back, this makes for a very clean UI (in my opinion at least). Right before creating this PR, I realized that I needed to make an additional API call to get the chef's profile after logging in since that API doesn't tell you if the chef has saved any recipes. This isn't an issue when creating an account since no recipes will be saved anyway.

I also took care of (finally) polishing the login dialog and fixing a few bugs I encountered while testing with TalkBack and different screen sizes. And I tried optimizing the number of API calls a bit more, but we might still need to raise the quota in the server. The only thing I didn't test was with different Android versions, but I'll save that toward the end to reduce the risk of missing any obscure bugs.

The main thing left to address is the recent recipes and how to handle caching. To continue delivering an offline-first experience, I would need to duplicate some of the server logic to Android's Room database. I would prefer this approach, but if it becomes too cumbersome, then I'll need to juggle between Room for unauthenticated users and MongoDB for authenticated users. (I need to populate the recent recipes map anyway by making authenticated calls to update the recipe's views.)

Then I need to decide what to do about the recent recipes on the home screen vs. the profile screen. It would be easier for users to access recipes, but if I make the home screen too crowded, it could be overwhelming for the user. Maybe I could move the accordions to the home screen so the user can decide if they want to view the recipes. The profile screen would then be reduced to just profile management. Whatever I decide, I would like the final product to "just work" from the user's perspective. More specifically, if I want to view the recipe and make any updates (add to favorites or rate it), those updates should be reflected almost immediately and the changes should be synced if I switch to a different client. We've come so far, but we've got this. 🤜🤛