### PR TITLE
Pass the state when logging in with OAuth

### DIFF
--- a/EZRecipes/app/build.gradle.kts
+++ b/EZRecipes/app/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
     val espressoVersion = "3.7.0"
 
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
-    implementation("androidx.core:core-ktx:1.18.0")
+    implementation("androidx.core:core-ktx:1.19.0")
     implementation("androidx.core:core-splashscreen:1.2.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion")

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/OAuthRequest.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/data/chef/OAuthRequest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class OAuthRequest(
     val code: String,
+    val state: String,
     val providerId: Provider,
     val redirectUrl: String
 )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/MainActivity.kt
@@ -59,12 +59,13 @@ class MainActivity : ComponentActivity() {
             Log.d(TAG, "action = $action")
 
             val code = appLinkData?.getQueryParameter("code")
-            Log.d(TAG, "code = $code")
+            val state = appLinkData?.getQueryParameter("state")
+            Log.d(TAG, "code = $code, state = $state")
             // Only update the ViewModel if the deep link matches the OAuth callback
             if (appLinkData?.scheme == Constants.REDIRECT_URI.scheme &&
                 appLinkData?.host == Constants.REDIRECT_URI.host &&
                 appLinkData?.path == Constants.REDIRECT_URI.path) {
-                profileViewModel.authCode = code
+                profileViewModel.oAuthResponse = Pair(code, state)
             }
         }
     }

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModel.kt
@@ -50,7 +50,7 @@ class ProfileViewModel(
     var authUrls by mutableStateOf<Map<Provider, Uri>>(mapOf())
         private set
     // "" = auth code not used, null = auth code missing
-    var authCode by mutableStateOf<String?>("")
+    var oAuthResponse by mutableStateOf<Pair<String?, String?>>(Pair("", ""))
     var provider by mutableStateOf<Provider?>(null)
     var accountLinked by mutableStateOf(false)
     var accountUnlinked by mutableStateOf(false)
@@ -333,9 +333,10 @@ class ProfileViewModel(
         }
     }
 
-    fun loginWithOAuth(code: String, provider: Provider) {
+    fun loginWithOAuth(code: String, state: String, provider: Provider) {
         val oAuthRequest = OAuthRequest(
             code = code,
+            state = state,
             providerId = provider,
             redirectUrl = Constants.REDIRECT_URL
         )

--- a/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/util/OAuthButton.kt
+++ b/EZRecipes/app/src/main/java/com/abhiek/ezrecipes/ui/util/OAuthButton.kt
@@ -8,12 +8,7 @@ import androidx.browser.auth.AuthTabIntent
 import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Surface
@@ -54,15 +49,24 @@ fun OAuthButton(
     val context = LocalContext.current
     val tag = "OAuthButton"
 
-    fun handleAuthCode(authCode: String?) {
+    fun handleAuth(authCode: String?, authState: String?) {
+        val expectedState = authUrl?.getQueryParameter("state")
+
         if (authCode == null) {
             profileViewModel.recipeError = RecipeError("No auth code received")
             profileViewModel.showAlert = true
+        } else if (authState == null || authState != expectedState) {
+            profileViewModel.recipeError = RecipeError("Invalid auth state received")
+            profileViewModel.showAlert = true
         } else {
-            profileViewModel.loginWithOAuth(authCode, profileViewModel.provider ?: provider)
+            profileViewModel.loginWithOAuth(
+                authCode,
+                authState,
+                profileViewModel.provider ?: provider
+            )
         }
 
-        profileViewModel.authCode = ""
+        profileViewModel.oAuthResponse = Pair("", "")
         profileViewModel.provider = null
     }
 
@@ -88,15 +92,18 @@ fun OAuthButton(
             return@rememberLauncherForActivityResult
         }
 
-        // Extract the authorization code from the redirect and then exchange it for an ID token
+        // Extract the authorization code from the redirect URL and then exchange it for an ID token
         val authCode = result.resultUri?.getQueryParameter("code")
-        handleAuthCode(authCode)
+        val authState = result.resultUri?.getQueryParameter("state")
+        handleAuth(authCode, authState)
     }
 
     // Custom Tab handler
-    LaunchedEffect(profileViewModel.authCode) {
-        if (profileViewModel.authCode != "" && profileViewModel.provider == provider) {
-            handleAuthCode(profileViewModel.authCode)
+    LaunchedEffect(profileViewModel.oAuthResponse) {
+        val (code, state) = profileViewModel.oAuthResponse
+
+        if (profileViewModel.provider == provider && code != "" && state != "") {
+            handleAuth(code, state)
         }
     }
 

--- a/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
+++ b/EZRecipes/app/src/test/java/com/abhiek/ezrecipes/ui/profile/ProfileViewModelTest.kt
@@ -6,11 +6,7 @@ import androidx.credentials.exceptions.CreateCredentialCancellationException
 import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
 import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
-import com.abhiek.ezrecipes.data.chef.ChefRepository
-import com.abhiek.ezrecipes.data.chef.MockChefService
-import com.abhiek.ezrecipes.data.chef.AuthState
-import com.abhiek.ezrecipes.data.chef.Chef
-import com.abhiek.ezrecipes.data.chef.Provider
+import com.abhiek.ezrecipes.data.chef.*
 import com.abhiek.ezrecipes.data.models.RecipeError
 import com.abhiek.ezrecipes.data.recipe.MockRecipeService
 import com.abhiek.ezrecipes.data.recipe.RecipeRepository
@@ -427,12 +423,13 @@ internal class ProfileViewModelTest {
 
     @Test
     fun loginWithOAuthSuccess() = runTest {
-        // Given a code, provider, and token
+        // Given a code, state, provider, and token
         val code = "abc123"
+        val state = "state"
         val provider = Provider.GOOGLE
 
         // When linking the provider
-        viewModel.loginWithOAuth(code, provider)
+        viewModel.loginWithOAuth(code, state, provider)
 
         // Then the chef should be updated
         assertNull(viewModel.recipeError)
@@ -461,13 +458,14 @@ internal class ProfileViewModelTest {
 
     @Test
     fun loginWithOAuthError() = runTest {
-        // Given a code, provider, and token
+        // Given a code, state, provider, and token
         val code = "abc123"
+        val state = "state"
         val provider = Provider.GOOGLE
 
         // When linking the provider and an error occurs
         mockChefService.isSuccess = false
-        viewModel.loginWithOAuth(code, provider)
+        viewModel.loginWithOAuth(code, state, provider)
 
         // Then an error is shown
         assertNull(viewModel.chef)
@@ -479,13 +477,14 @@ internal class ProfileViewModelTest {
 
     @Test
     fun loginWithOAuthNoToken() = runTest {
-        // Given a code, provider, and no token
+        // Given a code, state, provider, and no token
         val code = "abc123"
+        val state = "state"
         val provider = Provider.GOOGLE
         coEvery { mockDataStoreService.getToken() } returns null
 
         // When logging in with the provider
-        viewModel.loginWithOAuth(code, provider)
+        viewModel.loginWithOAuth(code, state, provider)
 
         // Then the user should be authenticated
         assertNull(viewModel.recipeError)
@@ -511,14 +510,15 @@ internal class ProfileViewModelTest {
 
     @Test
     fun loginWithOAuthEmailNotVerified() = runTest {
-        // Given a code, provider, and no token
+        // Given a code, state, provider, and no token
         val code = "abc123"
+        val state = "state"
         val provider = Provider.GOOGLE
         coEvery { mockDataStoreService.getToken() } returns null
 
         // When logging in with the provider, and the email isn't verified
         mockChefService.isEmailVerified = false
-        viewModel.loginWithOAuth(code, provider)
+        viewModel.loginWithOAuth(code, state, provider)
 
         // Then a new chef should be created, but the user shouldn't be authenticated
         assertNull(viewModel.recipeError)


### PR DESCRIPTION
<img width="852" height="97" alt="image" src="https://github.com/user-attachments/assets/8929c8c9-a076-498a-81c7-dee11a09a63e" />

_The Android implementation of https://github.com/Abhiek187/ez-recipes-server/issues/530_

We distinguish the OAuth buttons by their provider, so in addition to passing the state, I added a check to verify if the state matches. This accounts for both the auth tab and custom tab intents.